### PR TITLE
Add ability to rent items by kit

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { HomePage } from '../pages/home/home';
 import { InventoryFilterPage } from '../pages/inventory-filter/inventory-filter';
 import { InventoryPage } from '../pages/inventory/inventory';
 import { ItemFilterPage } from '../pages/item-filter/item-filter';
+import { KitRentalPage } from '../pages/kit-rental/kit-rental';
 import { KitsPage } from '../pages/kits/kits';
 import { LoginPage } from '../pages/login/login';
 import { RentalPage } from '../pages/rental/rental';
@@ -53,6 +54,7 @@ import { getAuthHttp, cloudSettings } from '../services/auth-http-helpers';
     InventoryFilterPage,
     InventoryPage,
     ItemFilterPage,
+    KitRentalPage,
     KitsPage,
     LoginPage,
     RentalPage,
@@ -90,6 +92,7 @@ import { getAuthHttp, cloudSettings } from '../services/auth-http-helpers';
     InventoryFilterPage,
     InventoryPage,
     ItemFilterPage,
+    KitRentalPage,
     KitsPage,
     LoginPage,
     RentalPage,

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -288,11 +288,16 @@ export class ItemPropertyDataMock {
 
 export class KitDataMock {
   kits = TestData.kits;
+  kit = TestData.kit;
   kitItems = TestData.kitItems;
   resolve: boolean = true;
 
   public getKits() {
     return returnObservable(this.resolve, this.kits);
+  }
+
+  public getKit() {
+    return returnObservable(this.resolve, this.kit);
   }
 
   public getKitItems() {

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -12,8 +12,11 @@
     <img src="assets/img/stockpile_tipi.svg" alt="Stockpile logo">
   </div>
 
-  <button ion-button (click)="onTypeBarcode()" block [outline]="platform.is('cordova')">
+  <button ion-button (click)="onTypeBarcode()" block outline>
     Type Barcode
+  </button>
+  <button ion-button (click)="onRentKit()" block [outline]="platform.is('cordova')">
+    Rent Kit
   </button>
   <button ion-button (click)="onScanBarcode()" block *ngIf="platform.is('cordova')">
     Scan Barcode

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -25,6 +25,20 @@ describe('Home Page', () => {
     expect(fixture).toBeTruthy();
   });
 
+  it('gets kits', fakeAsync(() => {
+    instance.ngOnInit();
+    tick();
+    expect(instance.kits).toEqual(TestData.kits.results);
+  }));
+
+  it('shows toast if error while getting kits', fakeAsync(() => {
+    instance.kitData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.ngOnInit();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
   it('pushes rental page on pushPage() with \'Rent\' if item is avaiable', fakeAsync(() => {
     instance.itemData.item = TestData.apiItem;
     spyOn(instance.navCtrl, 'push');
@@ -79,6 +93,20 @@ describe('Home Page', () => {
   it('creates an alert onTypeBarcode()', () => {
     spyOn(instance.alertCtrl, 'create').and.callThrough();
     instance.onTypeBarcode();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
+
+  it('creates an alert onRentKit()', () => {
+    instance.kits = TestData.kits.results;
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onRentKit();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
+
+  it('creates an alert onRentKit() if there are no kits', () => {
+    instance.kits = [];
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onRentKit();
     expect(instance.alertCtrl.create).toHaveBeenCalled();
   });
 });

--- a/src/pages/kit-rental/kit-rental.html
+++ b/src/pages/kit-rental/kit-rental.html
@@ -1,0 +1,39 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Rent Kit</ion-title>
+  </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+
+  <ion-list>
+    <ion-item>{{ kit?.name }}</ion-item>
+
+    <ion-list-header>Items in kit</ion-list-header>
+    <ion-item *ngFor="let kitItem of kitItems">
+      <ion-icon name="checkmark" item-left *ngIf="kitItem.barcode"></ion-icon>
+      <h2>{{ kitItem.brand }} {{ kitItem.model }}</h2>
+      <button ion-button clear item-right color="dark" *ngIf="kitItem.barcode" (click)="onRemoveKitItem(kitItem.barcode)">
+        <ion-icon name="close"></ion-icon>
+      </button>
+    </ion-item>
+
+      <ion-list-header *ngIf="otherItems.length">Other Items</ion-list-header>
+      <ion-item *ngFor="let otherItem of otherItems">
+        <h2>{{ otherItem.brand }} {{ otherItem.model }}</h2>
+        <button ion-button clear item-right color="dark" (click)="onRemoveOtherItem(otherItem.barcode)">
+          <ion-icon name="close"></ion-icon>
+        </button>
+      </ion-item>
+  </ion-list>
+
+  <button ion-button (click)="onTypeBarcode()" block outline>
+    Add More Items
+  </button>
+  <button ion-button (click)="onScanBarcode()" block outline *ngIf="platform.is('cordova')">
+    Scan More Items
+  </button>
+  <button ion-button (click)="onContinue()" block>
+    Continue
+  </button>
+</ion-content>

--- a/src/pages/kit-rental/kit-rental.spec.ts
+++ b/src/pages/kit-rental/kit-rental.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { Actions, Messages } from '../../constants';
+import { TestData } from '../../test-data';
+
+import { KitRentalPage } from './kit-rental';
+import { ViewItemPage } from '../view-item/view-item';
+
+let fixture: ComponentFixture<KitRentalPage> = null;
+let instance: any = null;
+
+describe('KitRental Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([KitRentalPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets kit and kitItems', fakeAsync(() => {
+    instance.navParams.param = TestData.kit.kitID;
+    instance.kitData.kitItems = TestData.kitItems;
+    spyOn(instance.kitData, 'getKit').and.callThrough();
+    spyOn(instance.kitData, 'getKitItems').and.callThrough();
+    instance.ngOnInit();
+    tick();
+    expect(instance.kitData.getKit).toHaveBeenCalledWith(TestData.kit.kitID);
+    expect(instance.kitData.getKitItems).toHaveBeenCalledWith(TestData.kit.kitID);
+    expect(instance.kit).toEqual(TestData.kit);
+    expect(instance.kitItems).toEqual(TestData.kitItems.results);
+  }));
+
+  it('shows toast if error while getting kit and kitItems', fakeAsync(() => {
+    instance.kitData.resolve = false;
+    instance.navParams.param = TestData.kit.kitID;
+    spyOn(instance.notifications, 'showToast');
+    instance.ngOnInit();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledTimes(2);
+  }));
+
+  it('shows toast if error onAdd()', fakeAsync(() => {
+    instance.itemData.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.onAdd();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('shows toast if item is rented', fakeAsync(() => {
+    instance.itemData.item = TestData.rentedApiItem;
+    spyOn(instance.notifications, 'showToast');
+    instance.onAdd();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.itemAlreadyRented);
+  }));
+
+  it('shows toast if item is already added', fakeAsync(() => {
+    instance.items = TestData.items;
+    instance.itemData.item = TestData.items[0];
+    spyOn(instance.notifications, 'showToast');
+    instance.onAdd();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(Messages.itemAlreadyAdded);
+  }));
+
+  it('creates alert if item is not in kitItems', fakeAsync(() => {
+    instance.kitItems = JSON.parse(JSON.stringify(TestData.kitItems.results));
+    instance.itemData.item = TestData.apiItem;
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onAdd();
+    tick();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  }));
+
+  it('creates an alert onTypeBarcode()', () => {
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onTypeBarcode();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
+
+  it('calls barcodeScanner.scan() onScanBarcode()', fakeAsync(() => {
+    spyOn(instance.barcodeScanner, 'scan').and.callThrough();
+    spyOn(instance, 'onAdd');
+    instance.onScanBarcode();
+    tick();
+    expect(instance.barcodeScanner.scan).toHaveBeenCalled();
+    expect(instance.onAdd).toHaveBeenCalledWith(TestData.barcodeData.text);
+  }));
+
+  it('shows toast if error in onScanBarcode()', fakeAsync(() => {
+    instance.barcodeScanner.resolve = false;
+    spyOn(instance.notifications, 'showToast');
+    instance.onScanBarcode();
+    tick();
+    expect(instance.notifications.showToast).toHaveBeenCalledWith(TestData.error);
+  }));
+
+  it('it does nothing if scan is cancelled', fakeAsync(() => {
+    instance.barcodeScanner.cancel = true;
+    spyOn(instance.notifications, 'showToast');
+    spyOn(instance, 'onAdd');
+    instance.onScanBarcode();
+    tick();
+    expect(instance.onAdd).not.toHaveBeenCalled();
+    expect(instance.notifications.showToast).not.toHaveBeenCalled();
+  }));
+
+  it('pushes RentalDetailsPage on nav onContinue()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.onContinue();
+    expect(instance.navCtrl.push).toHaveBeenCalled();
+  });
+
+  it('shows alert if not all kitItems are scanned onContinue()', () => {
+    instance.kitItems = TestData.kitItemsWithBarcode.results;
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onContinue();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
+
+  it('removes kit item from the list onRemoveKitItem()', () => {
+    instance.items = JSON.parse(JSON.stringify(TestData.items));
+    instance.kitItems = TestData.kitItemsWithBarcode.results;
+    instance.onRemoveKitItem(TestData.barcode);
+    expect(instance.items).toEqual(TestData.itemsMinusOne);
+    expect(instance.kitItems).toEqual(TestData.kitItemsWithEmptyBarcode.results);
+  });
+
+  it('removes item from the list onRemoveOtherItem()', () => {
+    instance.items = JSON.parse(JSON.stringify(TestData.items));
+    instance.otherItems = JSON.parse(JSON.stringify(TestData.items));
+    instance.onRemoveOtherItem(TestData.barcode);
+    expect(instance.items).toEqual(TestData.itemsMinusOne);
+    expect(instance.otherItems).toEqual(TestData.itemsMinusOne);
+  });
+});

--- a/src/pages/kit-rental/kit-rental.ts
+++ b/src/pages/kit-rental/kit-rental.ts
@@ -1,0 +1,195 @@
+import { Component } from '@angular/core';
+import { NavController, AlertController, Platform, NavParams, Events } from 'ionic-angular';
+import { BarcodeScanner } from '@ionic-native/barcode-scanner';
+
+import { RentalDetailsPage } from '../rental-details/rental-details';
+import { Messages } from '../../constants';
+import { Notifications } from '../../providers/notifications';
+import { ItemData } from '../../providers/item-data';
+import { KitData } from '../../providers/kit-data';
+
+@Component({
+  selector: 'page-kit-rental',
+  templateUrl: 'kit-rental.html'
+})
+export class KitRentalPage {
+  kit;
+  kitItems = [];
+  items = [];
+  otherItems = [];
+
+  constructor(
+    public navCtrl: NavController,
+    public alertCtrl: AlertController,
+    public notifications: Notifications,
+    public itemData: ItemData,
+    public barcodeScanner: BarcodeScanner,
+    public platform: Platform,
+    public kitData: KitData,
+    public navParams: NavParams,
+    public events: Events
+  ) { }
+
+  /**
+   * Gets kit and kit items from api.
+   */
+  ngOnInit() {
+    const kitID = this.navParams.get('kitID');
+
+    this.kitData.getKit(kitID).subscribe(
+      kit => this.kit = kit,
+      err => this.notifications.showToast(err)
+    );
+
+    this.kitData.getKitItems(kitID).subscribe(
+      kitItems => this.kitItems = kitItems.results,
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  /**
+   * Checks if item can be added to the rental. Shows why if not, adds it if yes.
+   */
+  onAdd(barcode: string) {
+    this.itemData.getItem(barcode).subscribe(
+      item => {
+        if (item.available === 0) {
+          this.notifications.showToast(Messages.itemAlreadyRented);
+        } else if (this.items.some(listItem => listItem.barcode === item.barcode)) {
+          this.notifications.showToast(Messages.itemAlreadyAdded);
+        } else if (!this.kitItems.some(kitItem => kitItem.brandID === item.brandID && kitItem.modelID === item.modelID)) {
+          let alert = this.alertCtrl.create({
+            title: 'Item not in kit',
+            message: 'Are you sure you want to rent it with this kit?',
+            buttons: [
+              {
+                text: 'Cancel',
+                role: 'cancel'
+              },
+              {
+                text: 'Yes',
+                handler: () => {
+                  this.items.push(item);
+                  this.otherItems.push(item);
+                }
+              }
+            ]
+          });
+
+          alert.present();
+        } else {
+          this.items.push(item);
+          const index = this.kitItems.findIndex(kitItem => kitItem.brandID === item.brandID && kitItem.modelID === item.modelID);
+          this.kitItems[index].barcode = item.barcode;
+        }
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  /**
+   * Creates alert to let the user type in a barcode. Calls onAdd() with the
+   * result.
+   */
+  onTypeBarcode() {
+    let alert = this.alertCtrl.create({
+      title: 'Type Barcode',
+      inputs: [
+        {
+          name: 'barcode',
+          placeholder: 'Barcode'
+        }
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel'
+        },
+        {
+          text: 'Next',
+          handler: form => {
+            this.onAdd(form.barcode);
+          }
+        }
+      ]
+    });
+
+    alert.present();
+  }
+
+  /**
+   * Starts barcode scanner and calls onAdd() with barcode if it got a barcode.
+   */
+  onScanBarcode() {
+    this.barcodeScanner.scan().then(
+      barcodeData => {
+        if (!barcodeData.cancelled) {
+          this.onAdd(barcodeData.text);
+        }
+      },
+      err => this.notifications.showToast(err)
+    );
+  }
+
+  /**
+   * Pushes RentalDetailsPage on nav with items to rent.
+   */
+  onContinue() {
+    const remaining = this.kitItems.some(kitItem => !kitItem.barcode);
+
+    if (!remaining) {
+      this.navCtrl.push(RentalDetailsPage, {
+        items: this.items
+      });
+    } else {
+      let alert = this.alertCtrl.create({
+        title: 'You haven\'t scanned all the items in the kit',
+        message: 'Are you sure you want to continue?',
+        buttons: [
+          {
+            text: 'Cancel',
+            role: 'cancel'
+          },
+          {
+            text: 'Continue',
+            handler: () => {
+              this.navCtrl.push(RentalDetailsPage, {
+                items: this.items
+              });
+            }
+          }
+        ]
+      });
+
+      alert.present();
+    }
+  }
+
+  /**
+   * Removes kit item and item from the list of local items.
+   */
+  onRemoveKitItem(barcode: string) {
+    this.removeItem(barcode);
+
+    const kitItemindex = this.kitItems.findIndex(kitItem => kitItem.barcode === barcode);
+    this.kitItems[kitItemindex].barcode = '';
+  }
+
+  /**
+   * Removes item with the barcode from the list of local items.
+   */
+  onRemoveOtherItem(barcode: string) {
+    this.removeItem(barcode);
+
+    const otherItemIndex = this.otherItems.findIndex(item => item.barcode === barcode);
+    this.otherItems.splice(otherItemIndex, 1);
+  }
+
+  /**
+   * Removes item with the barcode from the list of local items.
+   */
+  private removeItem(barcode: string) {
+    const itemIndex = this.items.findIndex(item => item.barcode === barcode);
+    this.items.splice(itemIndex, 1);
+  }
+}

--- a/src/pages/rental/rental.spec.ts
+++ b/src/pages/rental/rental.spec.ts
@@ -173,7 +173,7 @@ describe('Rental Page', () => {
   });
 
   it('removes item from the list onRemoveItem()', () => {
-    instance.items = TestData.items;
+    instance.items = JSON.parse(JSON.stringify(TestData.items));
     instance.onRemoveItem(TestData.barcode);
     expect(instance.items).toEqual(TestData.itemsMinusOne);
   });

--- a/src/providers/kit-data.spec.ts
+++ b/src/providers/kit-data.spec.ts
@@ -22,6 +22,14 @@ describe('KitData Provider', () => {
     );
   });
 
+  it('calls api to get kit', () => {
+    instance.api.value = TestData.kit;
+    instance.getKits(TestData.kit.kitID).subscribe(
+      res => expect(res).toEqual(TestData.kit),
+      err => fail(err)
+    );
+  });
+
   it('calls api to get kit item', () => {
     instance.api.value = TestData.kitItems;
     instance.getKitItems().subscribe(

--- a/src/providers/kit-data.ts
+++ b/src/providers/kit-data.ts
@@ -24,6 +24,10 @@ export class KitData {
     });
   }
 
+  getKit(kitID: number) {
+    return this.api.get(`${Links.kit}/${kitID}`);
+  }
+
   getKitItems(kitID: number) {
     return this.api.get(`${Links.kit}/${kitID}${Links.model}`);
   }

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -36,14 +36,14 @@ export class TestData {
   };
 
   public static modifiedItems = [{
-    barcode: 'apple',
+    barcode: 'banana',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    barcode: 'banana',
+    barcode: 'apple',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
@@ -65,14 +65,14 @@ export class TestData {
   }];
 
   public static items = [{
-    barcode: 'apple',
+    barcode: 'banana',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    barcode: 'banana',
+    barcode: 'apple',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
@@ -96,14 +96,14 @@ export class TestData {
   public static barcode = 'mango';
 
   public static itemsMinusOne = [{
-    barcode: 'apple',
+    barcode: 'banana',
     brandID: 1,
     modelID: 1,
     categoryID: 1,
     available: 1
   },
   {
-    barcode: 'banana',
+    barcode: 'apple',
     brandID: 2,
     modelID: 2,
     categoryID: 1,
@@ -119,14 +119,14 @@ export class TestData {
 
   public static filteredItems = {
     results: [{
-      barcode: 'apple',
+      barcode: 'banana',
       brandID: 1,
       modelID: 1,
       categoryID: 1,
       available: 1
     },
     {
-      barcode: 'banana',
+      barcode: 'apple',
       brandID: 2,
       modelID: 2,
       categoryID: 1,
@@ -296,33 +296,49 @@ export class TestData {
 
   public static kitItems = {
     results: [
-      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' },
-      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
-      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' }
+      { kitID: 1, modelID: 1, model: 'T5i', brandID: 1, brand: 'Canon' },
+      { kitID: 1, modelID: 2, model: 'SM58', brandID: 2, brand: 'Shure' },
+      { kitID: 1, modelID: 3, model: 'e609', brandID: 3, brand: 'Sennheiser' }
     ]
   };
 
   public static addedKitItems = {
     results: [
-      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' },
-      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
-      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' },
-      { kitID: 1, modelID: 2, model: 'T5i', brandID: 3, brand: 'Canon' }
+      { kitID: 1, modelID: 1, model: 'T5i', brandID: 1, brand: 'Canon' },
+      { kitID: 1, modelID: 2, model: 'SM58', brandID: 2, brand: 'Shure' },
+      { kitID: 1, modelID: 3, model: 'e609', brandID: 3, brand: 'Sennheiser' },
+      { kitID: 1, modelID: 4, model: 'T5i', brandID: 4, brand: 'Canon' }
     ]
   };
 
   public static deletedKitItems = {
     results: [
-      { kitID: 1, modelID: 4, model: 'SM58', brandID: 5, brand: 'Shure' },
-      { kitID: 1, modelID: 6, model: 'e609', brandID: 7, brand: 'Sennheiser' }
+      { kitID: 1, modelID: 2, model: 'SM58', brandID: 2, brand: 'Shure' },
+      { kitID: 1, modelID: 3, model: 'e609', brandID: 3, brand: 'Sennheiser' }
+    ]
+  };
+
+  public static kitItemsWithBarcode = {
+    results: [
+      { kitID: 1, modelID: 1, model: 'T5i', brandID: 1, brand: 'Canon', barcode: 'mango' },
+      { kitID: 1, modelID: 2, model: 'SM58', brandID: 2, brand: 'Shure' },
+      { kitID: 1, modelID: 3, model: 'e609', brandID: 3, brand: 'Sennheiser' }
+    ]
+  };
+
+  public static kitItemsWithEmptyBarcode = {
+    results: [
+      { kitID: 1, modelID: 1, model: 'T5i', brandID: 1, brand: 'Canon', barcode: '' },
+      { kitID: 1, modelID: 2, model: 'SM58', brandID: 2, brand: 'Shure' },
+      { kitID: 1, modelID: 3, model: 'e609', brandID: 3, brand: 'Sennheiser' }
     ]
   };
 
   public static kitItem = {
     kitID: 1,
-    modelID: 2,
+    modelID: 4,
     model: 'T5i',
-    brandID: 3,
+    brandID: 4,
     brand: 'Canon'
   };
 


### PR DESCRIPTION
Closes #163 

This creates quite a bit of code duplication. The new kit rental page is similar to the regular rental page, but different enough that they cannot be combined into a single component. I will look into page creation abstraction in the near future.