### PR TITLE
Fix content going under statusbar

### DIFF
--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -1,3 +1,9 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>Login</ion-title>
+  </ion-navbar>
+</ion-header>
+
 <ion-content padding>
 	<div class="logo">
 		<img src="assets/img/stockpile_logo.svg" alt="Stockpile logo">

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -98,6 +98,9 @@ export class AppEffects {
       .map(() => {
         this.splashScreen.hide();
         this.statusBar.styleDefault();
+        this.statusBar.overlaysWebView(false);
+        const statusBarColor = this.platform.is('android') ? '#6d435a' : '#f8f8f8';
+        this.statusBar.backgroundColorByHexString(statusBarColor);
       }))
     .ignoreElements();
 

--- a/src/store/app/app.effects.ts
+++ b/src/store/app/app.effects.ts
@@ -98,8 +98,7 @@ export class AppEffects {
       .map(() => {
         this.splashScreen.hide();
         this.statusBar.styleDefault();
-        this.statusBar.overlaysWebView(false);
-        const statusBarColor = this.platform.is('android') ? '#6d435a' : '#f8f8f8';
+        const statusBarColor = this.platform.is('android') ? '#411a31' : '#f8f8f8';
         this.statusBar.backgroundColorByHexString(statusBarColor);
       }))
     .ignoreElements();


### PR DESCRIPTION
Closes #354.

I'm not sure this is the right solution to this problem. It fixes the problem on the login screen, but it looks like this on the other screens:

![image](https://user-images.githubusercontent.com/5354752/29501947-67c20a1c-85fa-11e7-807f-ae96085735bf.png)
