### PR TITLE
Sort results from api

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -64,7 +64,7 @@ import { RentalDetailsPage } from '../pages/rental-details/rental-details';
 import { TabsPage } from '../pages/tabs/tabs';
 import { ViewAccountPage } from '../pages/view-account/view-account';
 
-import { MapToIterablePipe } from '../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe, SortPipe } from '../pipes';
 
 import { Api } from '../providers/api';
 import { ApiUrl } from '../providers/api-url';
@@ -97,6 +97,7 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     MapToIterablePipe,
     RentalPage,
     RentalDetailsPage,
+    SortPipe,
     TabsPage,
     ViewAccountPage,
   ],
@@ -183,6 +184,7 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     OrganizationActions,
     OrganizationEffects,
     OrganizationService,
+    SortPipe,
     SplashScreen,
     StatusBar,
     UserActions,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export class Actions {
   public static return = 'Return';
   public static add = 'Add';
   public static edit = 'Edit';
-};
+}
 
 export class Links {
   public static authenticate = '/auth';

--- a/src/models/brands.ts
+++ b/src/models/brands.ts
@@ -2,6 +2,7 @@ export interface Brand {
   readonly brandID: number;
   readonly name: string;
   readonly organizationID: number;
+  readonly sortIndex: number;
 }
 
 export interface Brands {

--- a/src/models/categories.ts
+++ b/src/models/categories.ts
@@ -2,6 +2,7 @@ export interface Category {
   readonly categoryID: number;
   readonly name: string;
   readonly organizationID: number;
+  readonly sortIndex: number;
 }
 
 export interface Categories {

--- a/src/models/items.ts
+++ b/src/models/items.ts
@@ -9,6 +9,7 @@ export interface Item {
   readonly barcode: string;
   readonly notes: string;
   readonly available: boolean;
+  readonly sortIndex: number;
 }
 
 export interface Items {

--- a/src/models/kit-models.ts
+++ b/src/models/kit-models.ts
@@ -5,6 +5,7 @@ export interface KitModel {
   readonly brandID: number;
   readonly brand: string;
   readonly quantity: number;
+  readonly sortIndex: number;
 }
 
 export interface KitModels {

--- a/src/models/kits.ts
+++ b/src/models/kits.ts
@@ -2,6 +2,7 @@ export interface Kit {
   readonly kitID: number;
   readonly name: string;
   readonly organizationID: number;
+  readonly sortIndex: number;
 }
 
 export interface Kits {

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -4,6 +4,7 @@ export interface Model {
   readonly brand: string;
   readonly name: string;
   readonly organizationID: number;
+  readonly sortIndex: number;
 }
 
 export interface Models {

--- a/src/pages/add-kit-model/add-kit-model.ts
+++ b/src/pages/add-kit-model/add-kit-model.ts
@@ -64,7 +64,7 @@ export class AddKitModelPage {
         case Actions.edit:
           this.kitModelsActions.updateTemp(this.kitModel);
           break;
-      };
+      }
 
       this.navCtrl.pop();
     }

--- a/src/pages/edit-item/edit-item.ts
+++ b/src/pages/edit-item/edit-item.ts
@@ -11,8 +11,6 @@ import { CategoriesActions } from '../../store/categories/categories.actions';
 import { LayoutActions } from '../../store/layout/layout.actions';
 import { Observable } from 'rxjs/Observable';
 
-import { MapToIterablePipe } from '../../pipes';
-
 @Component({
   selector: 'page-edit-item',
   templateUrl: 'edit-item.html'

--- a/src/pages/edit-item/edit-item.ts
+++ b/src/pages/edit-item/edit-item.ts
@@ -11,7 +11,7 @@ import { CategoriesActions } from '../../store/categories/categories.actions';
 import { LayoutActions } from '../../store/layout/layout.actions';
 import { Observable } from 'rxjs/Observable';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe } from '../../pipes';
 
 @Component({
   selector: 'page-edit-item',

--- a/src/pages/fields/fields.html
+++ b/src/pages/fields/fields.html
@@ -12,7 +12,7 @@
 <ion-content>
   <ion-list>
     <ion-list-header>{{ typePlural }}</ion-list-header>
-    <button ion-item *ngFor="let field of (fields | async).results | mapToIterable" (click)="onViewField(field)">
+    <button ion-item *ngFor="let field of (fields | async).results | mapToIterable | sort" (click)="onViewField(field)">
       <h2>{{ field.name }}</h2>
     </button>
 

--- a/src/pages/fields/fields.ts
+++ b/src/pages/fields/fields.ts
@@ -4,7 +4,7 @@ import { NavController, NavParams } from 'ionic-angular';
 import { Actions } from '../../constants';
 import { EditFieldPage } from '../edit-field/edit-field';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe, SortPipe } from '../../pipes';
 import { Observable } from 'rxjs/Observable';
 
 @Component({

--- a/src/pages/inventory/inventory.html
+++ b/src/pages/inventory/inventory.html
@@ -26,7 +26,7 @@
   </ion-segment>
 
   <ion-list>
-    <button ion-item *ngFor="let item of (items | async).results | mapToIterable" (click)="onViewItem(item.barcode)">
+    <button ion-item *ngFor="let item of (items | async).results | mapToIterable | sort" (click)="onViewItem(item.barcode)">
       <h2>{{ item.brand }} {{ item.model }}</h2>
     </button>
 

--- a/src/pages/inventory/inventory.ts
+++ b/src/pages/inventory/inventory.ts
@@ -15,8 +15,7 @@ import { BrandsActions } from '../../store/brands/brands.actions';
 import { ModelsActions } from '../../store/models/models.actions';
 import { CategoriesActions } from '../../store/categories/categories.actions';
 import { Observable } from 'rxjs/Observable';
-
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe, SortPipe } from '../../pipes';
 
 @Component({
   selector: 'page-inventory',

--- a/src/pages/kit-rental/kit-rental.ts
+++ b/src/pages/kit-rental/kit-rental.ts
@@ -16,8 +16,6 @@ import { ItemsService } from '../../services/items.service';
 import { Items } from '../../models/items';
 import { Observable } from 'rxjs/Observable';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
-
 @Component({
   selector: 'page-kit-rental',
   templateUrl: 'kit-rental.html'

--- a/src/pages/kits/kits.html
+++ b/src/pages/kits/kits.html
@@ -14,7 +14,7 @@
 
 <ion-content>
   <ion-list>
-    <button ion-item *ngFor="let kit of (kits | async).results | mapToIterable" (click)="onViewKit(kit.kitID)">
+    <button ion-item *ngFor="let kit of (kits | async).results | mapToIterable | sort" (click)="onViewKit(kit.kitID)">
       <h2>{{ kit.name }}</h2>
     </button>
 

--- a/src/pages/kits/kits.ts
+++ b/src/pages/kits/kits.ts
@@ -6,7 +6,7 @@ import { EditKitPage } from '../edit-kit/edit-kit';
 import { Kits } from '../../models/kits';
 import { KitsService } from '../../services/kits.service';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe, SortPipe } from '../../pipes';
 
 import { Observable } from 'rxjs/Observable';
 

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -10,7 +10,7 @@ import { LoadingMessages } from '../../constants';
 import { LayoutActions } from '../../store/layout/layout.actions';
 import { dateLessThan } from '../../utils/validators';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe } from '../../pipes';
 
 @Component({
   selector: 'page-rental-details',

--- a/src/pages/rental-details/rental-details.ts
+++ b/src/pages/rental-details/rental-details.ts
@@ -8,7 +8,6 @@ import { Items } from '../../models/items';
 import { Observable } from 'rxjs/Observable';
 import { LoadingMessages } from '../../constants';
 import { LayoutActions } from '../../store/layout/layout.actions';
-import { dateLessThan } from '../../utils/validators';
 
 import { MapToIterablePipe } from '../../pipes';
 
@@ -75,7 +74,7 @@ export class RentalDetailsPage {
       const endDate = control.value.substring(0, 10);
 
       return startDate > endDate ? { invalid: endDate } : null;
-    }
+    };
   }
 
   get endDate() { return this.rentalForm.get('endDate'); }

--- a/src/pages/rental/rental.ts
+++ b/src/pages/rental/rental.ts
@@ -12,7 +12,7 @@ import { Items } from '../../models/items';
 import { Observable } from 'rxjs/Observable';
 import { LayoutActions } from '../../store/layout/layout.actions';
 
-import { MapToIterablePipe } from '../../pipes/map-to-iterable.pipe';
+import { MapToIterablePipe } from '../../pipes';
 
 @Component({
   selector: 'page-rental',

--- a/src/pipes/index.ts
+++ b/src/pipes/index.ts
@@ -1,0 +1,2 @@
+export * from './map-to-iterable.pipe';
+export * from './sort.pipe';

--- a/src/pipes/map-to-iterable.pipe.ts
+++ b/src/pipes/map-to-iterable.pipe.ts
@@ -8,6 +8,6 @@ export class MapToIterablePipe {
     if (!map) {
       return null;
     }
-    return Object.keys(map).map(key => map[key]);
+    return Object.values(map);
   }
 }

--- a/src/pipes/map-to-iterable.pipe.ts
+++ b/src/pipes/map-to-iterable.pipe.ts
@@ -1,13 +1,13 @@
 import { Pipe } from '@angular/core';
 
 @Pipe({
-    name: 'mapToIterable'
+  name: 'mapToIterable'
 })
 export class MapToIterablePipe {
-  transform(map: {}, args: any[] = null): any {
-    if (!map)
+  transform(map: {}): Array<any> {
+    if (!map) {
       return null;
-    return Object.keys(map)
-      .map((key) => map[key]);
+    }
+    return Object.keys(map).map(key => map[key]);
   }
 }

--- a/src/pipes/sort.pipe.spec.ts
+++ b/src/pipes/sort.pipe.spec.ts
@@ -1,0 +1,33 @@
+import { SortPipe } from './sort.pipe';
+import { TestData } from '../test-data';
+
+describe('Sort Pipe', () => {
+  let instance: SortPipe = null;
+
+  beforeEach(() => {
+    instance = new SortPipe();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
+
+  it('sorts a list', () => {
+    const list = [
+      { sortIndex: 3 },
+      { sortIndex: 5 },
+      { sortIndex: 1 },
+      { sortIndex: 2 },
+      { sortIndex: 4 }
+    ];
+    const sortedList = [
+      { sortIndex: 1 },
+      { sortIndex: 2 },
+      { sortIndex: 3 },
+      { sortIndex: 4 },
+      { sortIndex: 5 },
+    ];
+
+    expect(instance.transform(list)).toEqual(sortedList);
+  });
+});

--- a/src/pipes/sort.pipe.ts
+++ b/src/pipes/sort.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe } from '@angular/core';
+
+@Pipe({
+  name: 'sort'
+})
+export class SortPipe {
+  transform(list: Array<any> = []): Array<any> {
+    return list.slice().sort((a, b) => a.sortIndex - b.sortIndex);
+  }
+}

--- a/src/providers/api-url.ts
+++ b/src/providers/api-url.ts
@@ -17,4 +17,4 @@ export class ApiUrl {
       return '/api';
     }
   }
-};
+}

--- a/src/store/kit-models/kit-models.actions.ts
+++ b/src/store/kit-models/kit-models.actions.ts
@@ -19,7 +19,7 @@ export class KitModelsActions {
   static DELETE_TEMP = type('[Kit Models] Delete Temp');
   static CREATE_TEMP = type('[Kit Models] Create Temp');
   static UPDATE_TEMP = type('[Kit Models] Update Temp');
-  static RESET_TEMP_KIT_MODELS = type('[Kit Models] Reset Temp')
+  static RESET_TEMP_KIT_MODELS = type('[Kit Models] Reset Temp');
 
   constructor(
     private store: Store<AppState>

--- a/src/store/kit-models/kit-models.effects.ts
+++ b/src/store/kit-models/kit-models.effects.ts
@@ -81,7 +81,7 @@ export class KitModelsEffects {
       // Update the kit models
       kitModelsToUpdate.map(kitModel => {
         models.push(this.kitData.updateKitModel(action.payload.kitID, kitModel).toPromise());
-      })
+      });
 
       // Delete the kit models
       kitModelsToDelete.map(modelID => {

--- a/src/store/kit-models/kit-models.reducer.ts
+++ b/src/store/kit-models/kit-models.reducer.ts
@@ -41,7 +41,7 @@ export function kitModelsReducer(kitModels: KitModels = initialState, action: Ac
       return {
         ...kitModels,
         tempKitModels: [...kitModels.tempKitModels, action.payload],
-      }
+      };
     case KitModelsActions.UPDATE_TEMP:
       return {
         ...kitModels,

--- a/src/test.ts
+++ b/src/test.ts
@@ -89,7 +89,7 @@ import { KitData } from './providers/kit-data';
 import { ItemPropertyData } from './providers/item-property-data';
 import { UserData } from './providers/user-data';
 import { Notifications } from './providers/notifications';
-import { MapToIterablePipe } from './pipes/map-to-iterable.pipe';
+import { MapToIterablePipe, SortPipe } from './pipes';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -129,7 +129,8 @@ export class TestUtils {
     return TestBed.configureTestingModule({
       declarations: [
         ...components,
-        MapToIterablePipe
+        MapToIterablePipe,
+        SortPipe
       ],
       providers: [
         App, Form, Keyboard, DomController, MenuController, GestureController,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "experimentalDecorators": true,
     "lib": [
       "dom",
-      "es2015"
+      "es2017"
     ],
     "module": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
Closes #379 

Even though using a pipe for sorting [is not recommended by the Angular team](https://angular.io/guide/pipes#appendix-no-filterpipe-or-orderbypipe), I still decided to go that way. Because the data is provided from ngrx, it comes as a Map and is provided by an observable, so it cannot be sorted in place (unless the sorted array is stored in ngrx, but then we would run into complex code to keep that array up to date with changes. Which is the reason why we use maps instead of arrays in the first place).

So we will have to see if we run into performance issues while sorting big lists with a pipe. If not, this solution is much cleaner.