### PR TITLE
Add support for external renters

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ import { ModelsActions } from '../store/models/models.actions';
 import { CategoriesActions } from '../store/categories/categories.actions';
 import { ItemProperties } from '../constants';
 import { FieldsPage } from '../pages/fields/fields';
+import { ExternalRentersPage } from '../pages/external-renters/external-renters';
 
 import { Observable } from 'rxjs/Observable';
 
@@ -85,6 +86,14 @@ export class StockpileApp {
   onViewInfo() {
     this.menuCtrl.close();
     this.nav.push(ViewAccountPage);
+  }
+
+  /**
+   * Closes side menu and pushes ExternalRentersPage.
+   */
+  onViewExternalRenters() {
+    this.menuCtrl.close();
+    this.nav.push(ExternalRentersPage);
   }
 
   /**

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,6 +12,9 @@
         <h3>{{(user | async)?.email}}</h3>
         <p>{{(organization | async)?.name}}</p>
       </button>
+      <button ion-item (click)="onViewExternalRenters()">
+        External Renters
+      </button>
       <button ion-item (click)="onViewBrands()">
         Brands
       </button>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,13 +44,18 @@ import { ItemsEffects } from '../store/items/items.effects';
 import { ItemsService } from '../services/items.service';
 import { LayoutActions } from '../store/layout/layout.actions';
 import { LayoutService } from '../services/layout.service';
+import { ExternalRentersActions } from '../store/external-renters/external-renters.actions';
+import { ExternalRentersEffects } from '../store/external-renters/external-renters.effects';
+import { ExternalRentersService } from '../services/external-renters.service';
 
 import { AddKitModelPage } from '../pages/add-kit-model/add-kit-model';
 import { ChangePasswordPage } from '../pages/change-password/change-password';
 import { EditAccountPage } from '../pages/edit-account/edit-account';
+import { EditExternalRenterPage } from '../pages/edit-external-renter/edit-external-renter';
 import { EditItemPage } from '../pages/edit-item/edit-item';
 import { EditFieldPage } from '../pages/edit-field/edit-field';
 import { EditKitPage } from '../pages/edit-kit/edit-kit';
+import { ExternalRentersPage } from '../pages/external-renters/external-renters';
 import { FieldsPage } from '../pages/fields/fields';
 import { HomePage } from '../pages/home/home';
 import { InventoryFilterPage } from '../pages/inventory-filter/inventory-filter';
@@ -68,6 +73,7 @@ import { MapToIterablePipe, SortPipe } from '../pipes';
 
 import { Api } from '../providers/api';
 import { ApiUrl } from '../providers/api-url';
+import { ExternalRenterData } from '../providers/external-renter-data';
 import { ItemData } from '../providers/item-data';
 import { ItemPropertyData } from '../providers/item-property-data';
 import { KitData } from '../providers/kit-data';
@@ -83,9 +89,11 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     AddKitModelPage,
     ChangePasswordPage,
     EditAccountPage,
+    EditExternalRenterPage,
     EditItemPage,
     EditFieldPage,
     EditKitPage,
+    ExternalRentersPage,
     FieldsPage,
     HomePage,
     InventoryFilterPage,
@@ -119,6 +127,7 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     EffectsModule.run(ModelsEffects),
     EffectsModule.run(CategoriesEffects),
     EffectsModule.run(ItemsEffects),
+    EffectsModule.run(ExternalRentersEffects),
   ],
   bootstrap: [IonicApp],
   entryComponents: [
@@ -126,9 +135,11 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     AddKitModelPage,
     ChangePasswordPage,
     EditAccountPage,
+    EditExternalRenterPage,
     EditItemPage,
     EditFieldPage,
     EditKitPage,
+    ExternalRentersPage,
     FieldsPage,
     HomePage,
     InventoryFilterPage,
@@ -154,6 +165,10 @@ import { getAuthHttp, cloudSettings } from '../utils/auth-http-helpers';
     CategoriesActions,
     CategoriesEffects,
     CategoriesService,
+    ExternalRentersActions,
+    ExternalRenterData,
+    ExternalRentersEffects,
+    ExternalRentersService,
     InAppBrowser,
     ItemData,
     ItemPropertyData,

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -16,6 +16,7 @@ import {
 import { StockpileApp } from './app.component';
 import { ViewAccountPage } from '../pages/view-account/view-account';
 import { FieldsPage } from '../pages/fields/fields';
+import { ExternalRentersPage } from '../pages/external-renters/external-renters';
 import { TestData } from '../test-data';
 import { ItemProperties } from '../constants';
 import { Observable } from 'rxjs/Observable';
@@ -64,6 +65,14 @@ describe('Root Component', () => {
     instance.onViewInfo();
     expect(instance.menuCtrl.close).toHaveBeenCalled();
     expect(instance.nav.push).toHaveBeenCalledWith(ViewAccountPage);
+  });
+
+  it('pushes ExternalRentersPage on viewExternalRenters()', () => {
+    spyOn(instance.menuCtrl, 'close');
+    spyOn(instance.nav, 'push');
+    instance.onViewExternalRenters();
+    expect(instance.menuCtrl.close).toHaveBeenCalled();
+    expect(instance.nav.push).toHaveBeenCalledWith(ExternalRentersPage);
   });
 
   it('pushes FieldsPage with brands on viewBrands()', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,6 +97,7 @@ export class ItemProperties {
   public static category = 'Category';
   public static categoryPlural = 'Categories';
   public static status = 'Status';
+  public static externalRenter = 'External Renter';
 }
 
 export const paginationLimit = 10;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export class Links {
   public static password = '/password';
   public static kit = '/kit';
   public static active = '/active';
+  public static externalRenter = '/external-renter';
 }
 
 export class Messages {
@@ -27,6 +28,7 @@ export class Messages {
   private static itemBaseSingular = 'Item successfully';
   private static itemBasePlural = 'Item(s) successfully';
   private static kitBaseSingular = 'Kit successfully';
+  private static externalRenterBaseSingular = 'External Renter successfully';
   private static itemAlready = 'Item is already';
   public static brandAdded = `${Messages.brandBaseSingular} created`;
   public static brandEdited = `${Messages.brandBaseSingular} updated`;
@@ -37,6 +39,9 @@ export class Messages {
   public static categoryAdded = `${Messages.categoryBaseSingular} created`;
   public static categoryEdited = `${Messages.categoryBaseSingular} updated`;
   public static categoryDeleted = `${Messages.categoryBaseSingular} deleted`;
+  public static externalRenterAdded = `${Messages.externalRenterBaseSingular} created`;
+  public static externalRenterEdited = `${Messages.externalRenterBaseSingular} updated`;
+  public static externalRenterDeleted = `${Messages.externalRenterBaseSingular} deleted`;
   public static itemAdded = `${Messages.itemBaseSingular} created`;
   public static itemEdited = `${Messages.itemBaseSingular} updated`;
   public static itemDeleted = `${Messages.itemBaseSingular} deleted`;
@@ -65,6 +70,9 @@ export class LoadingMessages {
   public static creatingCategory = 'Creating category...';
   public static updatingCategory = 'Updating category...';
   public static deletingCategory = 'Deleting category...';
+  public static creatingExternalRenter = 'Creating external renter...';
+  public static updatingExternalRenter = 'Updating external renter...';
+  public static deletingExternalRenter = 'Deleting external renter...';
   public static creatingKit = 'Creating kit...';
   public static updatingKit = 'Updating kit...';
   public static deletingKit = 'Deleting kit...';

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -274,6 +274,28 @@ export class ItemDataMock {
   }
 }
 
+export class ExternalRenterDataMock {
+  externalRenters = TestData.externalRenters;
+  externalRenter = TestData.externalRenter;
+  resolve: boolean = true;
+
+  public getExternalRenters(): any {
+    return returnObservable(this.resolve, this.externalRenters);
+  }
+
+  public createExternalRenter(): any {
+    return returnObservable(this.resolve, TestData.response);
+  }
+
+  public updateExternalRenter(): any {
+    return returnObservable(this.resolve, TestData.response);
+  }
+
+  public deleteExternalRenter() :any {
+    return returnObservable(this.resolve, TestData.response);
+  }
+}
+
 export class ItemPropertyDataMock {
   brands = TestData.brands;
   brand = TestData.brand;
@@ -444,6 +466,14 @@ export class CategoriesActionsMock {
   public filterCategories() {}
 }
 
+export class ExternalRentersActionsMock {
+  public fetchExternalRenters() {}
+  public createExternalRenter() {}
+  public updateExternalRenter() {}
+  public deleteExternalRenter() {}
+  public filteredItems() {}
+}
+
 export class ItemsActionsMock {
   public fetchItems() {}
   public createItem() {}
@@ -516,6 +546,20 @@ export class BrandsServiceMock {
 export class CategoriesServiceMock {
   public getCategories() {
     return Observable.of(TestData.categories);
+  }
+
+  public getShouldShowAddNew() {
+    return Observable.of(TestData.showAddNew);
+  }
+}
+
+export class ExternalRentersServiceMock {
+  public getExternalRenters() {
+    return Observable.of(TestData.externalRenters);
+  }
+
+  public getExternalRenter() {
+    return Observable.of(TestData.externalRenter);
   }
 
   public getShouldShowAddNew() {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -471,7 +471,7 @@ export class ExternalRentersActionsMock {
   public createExternalRenter() {}
   public updateExternalRenter() {}
   public deleteExternalRenter() {}
-  public filteredItems() {}
+  public filterExternalRenters() {}
 }
 
 export class ItemsActionsMock {

--- a/src/models/app-state.ts
+++ b/src/models/app-state.ts
@@ -7,6 +7,7 @@ import { Models } from './models';
 import { Categories } from './categories';
 import { Items } from './items';
 import { Layout } from './layout';
+import { ExternalRenters } from './external-renters';
 
 export interface AppState {
   readonly user: User;
@@ -18,4 +19,5 @@ export interface AppState {
   readonly categories: Categories;
   readonly items: Items;
   readonly layout: Layout;
+  readonly externalRenters: ExternalRenters;
 }

--- a/src/models/external-renters.ts
+++ b/src/models/external-renters.ts
@@ -1,0 +1,15 @@
+export interface ExternalRenter {
+  readonly externalRenterID: number;
+  readonly name: string;
+  readonly email: string;
+  readonly phone: string;
+  readonly organizationID: number;
+  readonly sortIndex: number;
+}
+
+export interface ExternalRenters {
+  readonly results: { [externalRenterID: number]: ExternalRenter };
+  readonly filtered: Array<ExternalRenter>;
+  readonly showAddNew: boolean;
+  readonly showLoadingSpinner: boolean;
+}

--- a/src/pages/edit-external-renter/edit-external-renter.html
+++ b/src/pages/edit-external-renter/edit-external-renter.html
@@ -1,0 +1,41 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>{{ action }} External Renter</ion-title>
+    <ion-buttons *ngIf="action === actions.edit" end>
+      <button ion-button icon-only (click)="onDelete()">
+        <ion-icon name="trash"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content>
+  <form [formGroup]="externalRenterForm" (ngSubmit)="onSave()">
+    <ion-item>
+      <ion-label floating color="primary">Name</ion-label>
+      <ion-input [ngModel]="(externalRenter | async)?.name" type="text" formControlName="name" (ionBlur)="blur.name = true"></ion-input>
+    </ion-item>
+    <p ion-text *ngIf="name.errors?.required && blur.name" color="danger" padding-left>
+      Name is required
+    </p>
+
+    <ion-item>
+      <ion-label floating color="primary">Email</ion-label>
+      <ion-input [ngModel]="(externalRenter | async)?.email" type="email" formControlName="email" (ionBlur)="blur.email = true"></ion-input>
+    </ion-item>
+    <p ion-text *ngIf="email.errors?.required && blur.email" color="danger" padding-left>
+      Please enter a valid email
+    </p>
+
+    <ion-item>
+      <ion-label floating color="primary">Phone Number</ion-label>
+      <ion-input [ngModel]="(externalRenter | async)?.phone" type="number" formControlName="phone" (ionBlur)="blur.phone = true"></ion-input>
+    </ion-item>
+
+    <div padding>
+    	<button ion-button type="submit" block>
+        Save
+      </button>
+    </div>
+	</form>
+</ion-content>

--- a/src/pages/edit-external-renter/edit-external-renter.spec.ts
+++ b/src/pages/edit-external-renter/edit-external-renter.spec.ts
@@ -1,0 +1,161 @@
+import { ComponentFixture, async } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions, LoadingMessages } from '../../constants';
+
+import { EditExternalRenterPage } from './edit-external-renter';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+let fixture: ComponentFixture<EditExternalRenterPage> = null;
+let instance: any = null;
+
+describe('EditExternalRenter Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([EditExternalRenterPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  const updateForm = (name: string, email: string, phone: number) => {
+    instance.externalRenterForm.controls['name'].setValue(name);
+    instance.externalRenterForm.controls['email'].setValue(email);
+    instance.externalRenterForm.controls['phone'].setValue(phone);
+  }
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets navParam action', () => {
+    instance.navParams.param = Actions.add;
+    instance.ngOnInit();
+    expect(instance.action).toEqual(Actions.add);
+  });
+
+  it('updates form with values', () => {
+    instance.ngOnInit();
+    updateForm(
+      TestData.externalRenter.name,
+      TestData.externalRenter.email,
+      TestData.externalRenter.phone
+    );
+    expect(instance.externalRenterForm.value).toEqual({
+      name: TestData.externalRenter.name,
+      email: TestData.externalRenter.email,
+      phone: TestData.externalRenter.phone
+    });
+  });
+
+  it('validates name', () => {
+    instance.ngOnInit();
+    updateForm('');
+    expect(instance.externalRenterForm.controls.name.valid).toEqual(false);
+    updateForm(TestData.externalRenter.name);
+    expect(instance.externalRenterForm.controls.name.valid).toEqual(true);
+  });
+
+  it('sets blur to true onSave()', () => {
+    instance.externalRenterForm = { valid: false };
+    instance.onSave();
+    expect(instance.blur).toEqual({
+      name: true,
+      email: true,
+      phone: true
+    });
+  });
+
+  it('creates external renter onSave() if action is add', () => {
+    instance.externalRenterForm = {
+      value: {
+        name: TestData.externalRenter.name,
+        email: TestData.externalRenter.email,
+        phone: TestData.externalRenter.phone
+      },
+      valid: true
+    };
+    instance.action = Actions.add;
+    spyOn(instance.layoutActions, 'showLoadingMessage');
+    spyOn(instance.externalRentersActions, 'createExternalRenter');
+    instance.onSave();
+    expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.creatingExternalRenter);
+    expect(instance.externalRentersActions.createExternalRenter).toHaveBeenCalledWith({
+      name: TestData.externalRenter.name,
+      email: TestData.externalRenter.email,
+      phone: TestData.externalRenter.phone
+    }, true);
+  });
+
+  it('updates external renter onSave() if action is edit', () => {
+    instance.externalRenterForm = {
+      value: {
+        name: TestData.externalRenter.name,
+        email: TestData.externalRenter.email,
+        phone: TestData.externalRenter.phone
+      },
+      valid: true
+    };
+    instance.action = Actions.edit;
+    instance.externalRenter = Observable.of(TestData.externalRenter);
+    spyOn(instance.layoutActions, 'showLoadingMessage');
+    spyOn(instance.externalRentersActions, 'updateExternalRenter');
+    instance.onSave();
+    expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.updatingExternalRenter);
+    expect(instance.externalRentersActions.updateExternalRenter).toHaveBeenCalledWith({
+      name: TestData.externalRenter.name,
+      email: TestData.externalRenter.email,
+      phone: TestData.externalRenter.phone,
+      externalRenterID: TestData.externalRenter.externalRenterID
+    });
+  });
+
+  it('it does not save kit onSave() if the form is invalid', () => {
+    instance.externalRenterForm = { valid: false };
+    spyOn(instance.externalRentersActions, 'updateExternalRenter');
+    spyOn(instance.externalRentersActions, 'createExternalRenter');
+    instance.onSave();
+    expect(instance.externalRentersActions.updateExternalRenter).not.toHaveBeenCalled();
+    expect(instance.externalRentersActions.createExternalRenter).not.toHaveBeenCalled();
+  });
+
+  it('creates an alert onDelete()', () => {
+    spyOn(instance.alertCtrl, 'create').and.callThrough();
+    instance.onDelete();
+    expect(instance.alertCtrl.create).toHaveBeenCalled();
+  });
+
+  it('deletes external renter on deleteExternalRenter()', () => {
+    instance.externalRenter = Observable.of(TestData.externalRenter);
+    spyOn(instance.layoutActions, 'showLoadingMessage');
+    spyOn(instance.externalRentersActions, 'deleteExternalRenter');
+    instance.deleteExternalRenter();
+    expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.deletingExternalRenter);
+    expect(instance.externalRentersActions.deleteExternalRenter).toHaveBeenCalledWith(TestData.externalRenter.externalRenterID);
+  });
+
+  it('gets name', () => {
+    instance.externalRenterForm = {
+      get: (key: string) => TestData.externalRenter[key]
+    };
+    expect(instance.name).toEqual(TestData.externalRenter.name);
+  });
+
+  it('gets email', () => {
+    instance.externalRenterForm = {
+      get: (key: string) => TestData.externalRenter[key]
+    };
+    expect(instance.email).toEqual(TestData.externalRenter.email);
+  });
+
+  it('gets phone', () => {
+    instance.externalRenterForm = {
+      get: (key: string) => TestData.externalRenter[key]
+    };
+    expect(instance.phone).toEqual(TestData.externalRenter.phone);
+  });
+});

--- a/src/pages/edit-external-renter/edit-external-renter.ts
+++ b/src/pages/edit-external-renter/edit-external-renter.ts
@@ -1,0 +1,114 @@
+import { Component } from '@angular/core';
+import { Validators, FormBuilder, FormGroup } from '@angular/forms';
+import { NavController, NavParams, AlertController } from 'ionic-angular';
+
+import { ExternalRenter } from '../../models/external-renters';
+import { ExternalRentersService } from '../../services/external-renters.service';
+import { ExternalRentersActions } from '../../store/external-renters/external-renters.actions';
+import { LayoutActions } from '../../store/layout/layout.actions';
+
+import { Actions, LoadingMessages } from '../../constants';
+import { Observable } from 'rxjs/Observable';
+
+@Component({
+  selector: 'page-edit-external-renter',
+  templateUrl: 'edit-external-renter.html'
+})
+export class EditExternalRenterPage {
+  externalRenterForm: FormGroup;
+  blur = {
+    name: false,
+    email: false,
+    phone: false
+  };
+  actions = Actions;
+  action: Actions = '';
+  externalRenter: Observable<ExternalRenter>;
+
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams,
+    public alertCtrl: AlertController,
+    public externalRentersService: ExternalRentersService,
+    public externalRentersActions: ExternalRentersActions,
+    public layoutActions: LayoutActions,
+    public formBuilder: FormBuilder
+  ) {}
+
+  /**
+   * Gets the action (add or edit) and if action is edit, also gets the external
+   * renter.
+   */
+  ngOnInit() {
+    this.action = this.navParams.get('action');
+
+    this.externalRenterForm = this.formBuilder.group({
+      name: ['', Validators.required],
+      email: [''],
+      phone: ['']
+    });
+
+    if (this.action === Actions.edit) {
+      const externalRenterID = this.navParams.get('externalRenterID');
+      this.externalRenter = this.externalRentersService.getExternalRenter(externalRenterID);
+    }
+  }
+
+  /**
+   * Creates or updates the external renter.
+   */
+  onSave() {
+    this.blur.name = true;
+    this.blur.email = true;
+    this.blur.phone = true;
+
+    if (this.externalRenterForm.valid) {
+      if (this.action === Actions.add) {
+        this.layoutActions.showLoadingMessage(LoadingMessages.creatingExternalRenter);
+        this.externalRentersActions.createExternalRenter(this.externalRenterForm.value, true);
+      } else {
+        let externalRenterID;
+        this.externalRenter.take(1).subscribe(externalRenter => externalRenterID = externalRenter.externalRenterID);
+
+        this.layoutActions.showLoadingMessage(LoadingMessages.updatingExternalRenter);
+        this.externalRentersActions.updateExternalRenter({ ...this.externalRenterForm.value, externalRenterID });
+      }
+    }
+  }
+
+  /**
+   * Confirms if user wants to delete the kit.
+   */
+  onDelete() {
+    let alert = this.alertCtrl.create({
+      title: 'Are you sure you want to delete this external renter?',
+      message: 'It will be deleted permanently',
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel'
+        },
+        {
+          text: 'Delete',
+          handler: () => this.deleteExternalRenter()
+        }
+      ]
+    });
+    alert.present();
+  }
+
+  /**
+   * Deletes kit.
+   */
+  deleteExternalRenter() {
+    let externalRenterID;
+    this.externalRenter.take(1).subscribe(externalRenter => externalRenterID = externalRenter.externalRenterID);
+
+    this.layoutActions.showLoadingMessage(LoadingMessages.deletingExternalRenter);
+    this.externalRentersActions.deleteExternalRenter(externalRenterID);
+  }
+
+  get name() { return this.externalRenterForm.get('name'); }
+  get email() { return this.externalRenterForm.get('email'); }
+  get phone() { return this.externalRenterForm.get('phone'); }
+}

--- a/src/pages/edit-external-renter/edit-external-renter.ts
+++ b/src/pages/edit-external-renter/edit-external-renter.ts
@@ -77,7 +77,7 @@ export class EditExternalRenterPage {
   }
 
   /**
-   * Confirms if user wants to delete the kit.
+   * Confirms if user wants to delete the external renter.
    */
   onDelete() {
     let alert = this.alertCtrl.create({
@@ -98,7 +98,7 @@ export class EditExternalRenterPage {
   }
 
   /**
-   * Deletes kit.
+   * Deletes external renter.
    */
   deleteExternalRenter() {
     let externalRenterID;

--- a/src/pages/external-renters/external-renters.html
+++ b/src/pages/external-renters/external-renters.html
@@ -1,0 +1,25 @@
+<ion-header>
+  <ion-navbar>
+    <ion-title>External Renters</ion-title>
+    <ion-buttons end>
+      <button ion-button icon-only (click)="onAdd()">
+        <ion-icon name="add"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <button ion-item *ngFor="let externalRenter of (externalRenters | async).results | mapToIterable | sort"
+      (click)="onViewExternalRenter(externalRenter.externalRenterID)">
+      <h2>{{ externalRenter.name }}</h2>
+    </button>
+
+    <ion-item *ngIf="!((externalRenters | async).results | mapToIterable).length && !(externalRenters | async).showLoadingSpinner">
+      No external renters found <button ion-button item-right (click)="onAdd()">Add an external renter</button>
+    </ion-item>
+
+    <ion-spinner class="center-spinner" *ngIf="(externalRenters | async).showLoadingSpinner"></ion-spinner>
+  </ion-list>
+</ion-content>

--- a/src/pages/external-renters/external-renters.spec.ts
+++ b/src/pages/external-renters/external-renters.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, async } from '@angular/core/testing';
+import { TestUtils } from '../../test';
+import { TestData } from '../../test-data';
+import { Actions } from '../../constants';
+
+import { ExternalRentersPage } from './external-renters';
+import { EditExternalRenterPage } from '../edit-external-renter/edit-external-renter';
+import { Observable } from 'rxjs/Observable';
+
+let fixture: ComponentFixture<ExternalRentersPage> = null;
+let instance: any = null;
+
+describe('ExternalRenters Page', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([ExternalRentersPage]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+    expect(fixture).toBeTruthy();
+  });
+
+  it('gets external renters', () => {
+    spyOn(instance.externalRentersActions, 'fetchExternalRenters');
+    instance.ngOnInit();
+    expect(instance.externalRentersActions.fetchExternalRenters).toHaveBeenCalled();
+  });
+
+  it('pushes EditExternalRenterPage on nav onViewExternalRenter()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.onViewExternalRenter(TestData.externalRenter.externalRenterID);
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(EditExternalRenterPage, {
+      action: Actions.edit,
+      externalRenterID: TestData.externalRenter.externalRenterID
+    });
+  });
+
+  it('pushes EditExternalRenterPage on nav on add()', () => {
+    spyOn(instance.navCtrl, 'push');
+    instance.onAdd();
+    expect(instance.navCtrl.push).toHaveBeenCalledWith(EditExternalRenterPage, {
+      action: Actions.add,
+    });
+  });
+});

--- a/src/pages/external-renters/external-renters.ts
+++ b/src/pages/external-renters/external-renters.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { NavController, NavParams } from 'ionic-angular';
+
+import { Actions } from '../../constants';
+import { EditExternalRenterPage } from '../edit-external-renter/edit-external-renter';
+import { ExternalRenters } from '../../models/external-renters';
+import { ExternalRentersService } from '../../services/external-renters.service';
+import { ExternalRentersActions } from '../../store/external-renters/external-renters.actions';
+
+import { MapToIterablePipe, SortPipe } from '../../pipes';
+import { Observable } from 'rxjs/Observable';
+
+@Component({
+  selector: 'page-external-renters',
+  templateUrl: 'external-renters.html'
+})
+export class ExternalRentersPage {
+  externalRenters: Observable<ExternalRenters>;
+
+  constructor(
+    public navCtrl: NavController,
+    public externalRentersService: ExternalRentersService,
+    public externalRentersActions: ExternalRentersActions
+  ) {}
+
+  /**
+   * Gets external renters.
+   */
+  ngOnInit() {
+    this.externalRenters = this.externalRentersService.getExternalRenters();
+    this.externalRentersActions.fetchExternalRenters();
+  }
+
+  /**
+   * Pushes page on nav to allow user to view the external field.
+   */
+  onViewExternalRenter(externalRenterID: number) {
+    this.navCtrl.push(EditExternalRenterPage, { action: Actions.edit, externalRenterID });
+  }
+
+  /**
+   * Pushes page on nav to allow user to add a new external field.
+   */
+  onAdd() {
+    this.navCtrl.push(EditExternalRenterPage, { action: Actions.add });
+  }
+}

--- a/src/pages/external-renters/external-renters.ts
+++ b/src/pages/external-renters/external-renters.ts
@@ -32,14 +32,14 @@ export class ExternalRentersPage {
   }
 
   /**
-   * Pushes page on nav to allow user to view the external field.
+   * Pushes page on nav to allow user to view the external renter.
    */
   onViewExternalRenter(externalRenterID: number) {
     this.navCtrl.push(EditExternalRenterPage, { action: Actions.edit, externalRenterID });
   }
 
   /**
-   * Pushes page on nav to allow user to add a new external field.
+   * Pushes page on nav to allow user to add a new external renter.
    */
   onAdd() {
     this.navCtrl.push(EditExternalRenterPage, { action: Actions.add });

--- a/src/pages/item-filter/item-filter.html
+++ b/src/pages/item-filter/item-filter.html
@@ -11,7 +11,7 @@
   <ion-toolbar>
     <ion-searchbar [(ngModel)]="queryText"
                    (ionInput)="onSearch($event)"
-                   placeholder="Filter {{ type }}"
+                   placeholder="Filter"
                    showCancelButton="true">
     </ion-searchbar>
   </ion-toolbar>

--- a/src/pages/item-filter/item-filter.spec.ts
+++ b/src/pages/item-filter/item-filter.spec.ts
@@ -5,9 +5,11 @@ import {
   NavParamsMock,
   BrandsActionsMock,
   CategoriesActionsMock,
+  ExternalRentersActionsMock,
   ModelsActionsMock,
   BrandsServiceMock,
   CategoriesServiceMock,
+  ExternalRentersServiceMock,
   ModelsServiceMock,
   LayoutActionsMock
 } from '../../mocks';
@@ -32,6 +34,8 @@ describe('ItemFilter Page', () => {
       <any> new ModelsServiceMock,
       <any> new CategoriesActionsMock,
       <any> new CategoriesServiceMock,
+      <any> new ExternalRentersActionsMock,
+      <any> new ExternalRentersServiceMock,
       <any> new LayoutActionsMock
     );
   });
@@ -96,6 +100,18 @@ describe('ItemFilter Page', () => {
     expect(instance.categoriesActions.filterCategories).toHaveBeenCalledWith(TestData.queryText);
   });
 
+  it('filters external renters on onSearch()', () => {
+    instance.type = ItemProperties.externalRenter;
+    const event = {
+      target: {
+        value: TestData.queryText
+      }
+    };
+    spyOn(instance.externalRentersActions, 'filterExternalRenters');
+    instance.onSearch(event);
+    expect(instance.externalRentersActions.filterExternalRenters).toHaveBeenCalledWith(TestData.queryText);
+  });
+
   it('dismisses modal on dismiss()', () => {
     spyOn(instance.viewCtrl, 'dismiss');
     instance.onDismiss(TestData.brand);
@@ -138,5 +154,15 @@ describe('ItemFilter Page', () => {
     instance.createNewElement(TestData.category.name);
     expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.creatingCategory);
     expect(instance.categoriesActions.createCategory).toHaveBeenCalledWith(TestData.category.name);
+  });
+
+  it('creates new external renter on createNewElement() if type is external renter', () => {
+    instance.elements = Observable.of(TestData.externalRenters);
+    instance.type = ItemProperties.externalRenter;
+    spyOn(instance.layoutActions, 'showLoadingMessage');
+    spyOn(instance.externalRentersActions, 'createExternalRenter');
+    instance.createNewElement(TestData.externalRenter.name);
+    expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.creatingExternalRenter);
+    expect(instance.externalRentersActions.createExternalRenter).toHaveBeenCalledWith({ name: TestData.externalRenter.name });
   });
 });

--- a/src/pages/item-filter/item-filter.ts
+++ b/src/pages/item-filter/item-filter.ts
@@ -4,10 +4,13 @@ import { ItemProperties, LoadingMessages } from '../../constants';
 import { BrandsService } from '../../services/brands.service';
 import { ModelsService } from '../../services/models.service';
 import { CategoriesService } from '../../services/categories.service';
+import { ExternalRentersService } from '../../services/external-renters.service';
 import { BrandsActions } from '../../store/brands/brands.actions';
 import { ModelsActions } from '../../store/models/models.actions';
 import { CategoriesActions } from '../../store/categories/categories.actions';
+import { ExternalRentersActions } from '../../store/external-renters/external-renters.actions';
 import { LayoutActions } from '../../store/layout/layout.actions';
+import { EditExternalRenterPage } from '../../pages/edit-external-renter/edit-external-renter';
 import { Observable } from 'rxjs/Observable';
 
 @Component({
@@ -31,6 +34,8 @@ export class ItemFilterPage {
     public modelsService: ModelsService,
     public categoriesActions: CategoriesActions,
     public categoriesService: CategoriesService,
+    public externalRentersActions: ExternalRentersActions,
+    public externalRentersService: ExternalRentersService,
     public layoutActions: LayoutActions
   ) {}
 
@@ -58,6 +63,10 @@ export class ItemFilterPage {
         this.elements = this.categoriesService.getCategories();
         this.showAddNew = this.categoriesService.getShouldShowAddNew();
         break;
+      case ItemProperties.externalRenter:
+        this.elements = this.externalRentersService.getExternalRenters();
+        this.showAddNew = this.externalRentersService.getShouldShowAddNew();
+        break;
     }
   }
 
@@ -82,6 +91,9 @@ export class ItemFilterPage {
         break;
       case ItemProperties.category:
         this.categoriesActions.filterCategories(text);
+        break;
+      case ItemProperties.externalRenter:
+        this.externalRentersActions.filterExternalRenters(text);
         break;
     }
   }
@@ -138,6 +150,9 @@ export class ItemFilterPage {
         this.layoutActions.showLoadingMessage(LoadingMessages.creatingCategory);
         this.categoriesActions.createCategory(name);
         break;
+      case ItemProperties.externalRenter:
+        this.layoutActions.showLoadingMessage(LoadingMessages.creatingExternalRenter);
+        this.externalRentersActions.createExternalRenter({ name });
     }
 
     // Workaround to detect when the brand, model or category has been

--- a/src/pages/rental-details/rental-details.html
+++ b/src/pages/rental-details/rental-details.html
@@ -24,6 +24,11 @@
         </p>
       </div>
 
+      <button ion-item type="button" (click)="onSelectExternalRenter()" tappable detail-none>
+        <ion-label color="primary">External Renter</ion-label>
+        <ion-label>{{ externalRenter?.name }}</ion-label>
+      </button>
+
       <ion-item>
         <ion-label floating color="primary">Notes</ion-label>
         <ion-textarea type="text" formControlName="notes"></ion-textarea>

--- a/src/pages/rental-details/rental-details.spec.ts
+++ b/src/pages/rental-details/rental-details.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, async } from '@angular/core/testing';
 import { TestUtils } from '../../test';
 import { TestData } from '../../test-data';
-import { LoadingMessages } from '../../constants';
+import { LoadingMessages, ItemProperties } from '../../constants';
 
+import { ItemFilterPage } from '../item-filter/item-filter';
 import { RentalDetailsPage } from './rental-details';
 
 let fixture: ComponentFixture<RentalDetailsPage> = null;
@@ -64,6 +65,7 @@ describe('RentalDetails Page', () => {
       value: TestData.details,
       valid: true
     };
+    instance.externalRenter = TestData.externalRenter;
     let today = new Date();
     today.setDate(today.getDate() - instance.timezoneOffset);
     spyOn(instance.layoutActions, 'showLoadingMessage');
@@ -72,6 +74,7 @@ describe('RentalDetails Page', () => {
     expect(instance.layoutActions.showLoadingMessage).toHaveBeenCalledWith(LoadingMessages.rentingItems);
     expect(instance.itemsActions.rentItems).toHaveBeenCalledWith({
       ...TestData.details,
+      externalRenterID: TestData.externalRenter.externalRenterID,
       startDate: today.toISOString().substring(0, 10)
     });
   });
@@ -83,6 +86,14 @@ describe('RentalDetails Page', () => {
     instance.onRent();
     expect(instance.layoutActions.showLoadingMessage).not.toHaveBeenCalled();
     expect(instance.itemsActions.rentItems).not.toHaveBeenCalled();
+  });
+
+  it('creates a modal on onSelectExternalRenter()', () => {
+    spyOn(instance.modalCtrl, 'create').and.callThrough();
+    instance.onSelectExternalRenter();
+    expect(instance.modalCtrl.create).toHaveBeenCalledWith(ItemFilterPage, {
+      type: ItemProperties.externalRenter
+    });
   });
 
   it('gets endDate', () => {

--- a/src/providers/external-renter-data.spec.ts
+++ b/src/providers/external-renter-data.spec.ts
@@ -1,0 +1,48 @@
+import { ExternalRenterData } from './external-renter-data';
+import { TestData } from '../test-data';
+import { ApiMock } from '../mocks';
+
+let instance: ExternalRenterData = null;
+
+describe('ExternalRenterData Provider', () => {
+
+  beforeEach(() => {
+    instance = new ExternalRenterData((<any> new ApiMock));
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
+
+  it('calls api to get external renters', () => {
+    instance.api.value = TestData.externalRenters.results;
+    instance.getExternalRenters().subscribe(
+      res => expect(res).toEqual(TestData.externalRenters.results),
+      err => fail(err)
+    );
+  });
+
+  it('calls api to create external renter', () => {
+    instance.api.value = TestData.response;
+    instance.createExternalRenter(TestData.externalRenter.name).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  });
+
+  it('calls api to update external renter', () => {
+    instance.api.value = TestData.response;
+    instance.updateExternalRenter(TestData.externalRenter, TestData.externalRenter.externalRenterID).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  });
+
+  it('calls api to delete external renter', () => {
+    instance.api.value = TestData.response;
+    instance.deleteExternalRenter(TestData.externalRenter.externalRenterID).subscribe(
+      res => expect(res).toEqual(TestData.response),
+      err => fail(err)
+    );
+  });
+});

--- a/src/providers/external-renter-data.ts
+++ b/src/providers/external-renter-data.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Links } from '../constants';
+import { Api } from '../providers/api';
+
+@Injectable()
+export class ExternalRenterData {
+
+  constructor(public api: Api) {}
+
+  getExternalRenters() {
+    return this.api.get(Links.externalRenter);
+  }
+
+  createExternalRenter(body: any) {
+    return this.api.put(Links.externalRenter, body);
+  }
+
+  updateExternalRenter(body: any, externalRenterID: number) {
+    return this.api.put(`${Links.externalRenter}/${externalRenterID}`, body);
+  }
+
+  deleteExternalRenter(externalRenterID: number) {
+    return this.api.delete(`${Links.externalRenter}/${externalRenterID}`);
+  }
+}

--- a/src/services/external-renters.service.spec.ts
+++ b/src/services/external-renters.service.spec.ts
@@ -1,0 +1,30 @@
+import { StoreMock } from '../mocks';
+import { ExternalRentersService } from './external-renters.service';
+import { TestData } from '../test-data';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+let instance: ExternalRentersService = null;
+
+describe('ExternalRenters Service', () => {
+
+  beforeEach(() => {
+    instance = new ExternalRentersService((<any> new StoreMock));
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
+
+  it('returns external renters', () => {
+    expect(instance.getExternalRenters()).toEqual(Observable.of(TestData.state.externalRenters));
+  });
+
+  it('returns external renter', () => {
+    expect(instance.getExternalRenter(TestData.externalRenter.externalRenterID)).toEqual(Observable.of(TestData.externalRenter));
+  });
+
+  it('returns showAddNew', () => {
+    expect(instance.getShouldShowAddNew()).toEqual(Observable.of(TestData.state.externalRenters.showAddNew));
+  });
+});

--- a/src/services/external-renters.service.ts
+++ b/src/services/external-renters.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+
+import { AppState } from '../models/app-state';
+import { ExternalRenters, ExternalRenter } from '../models/external-renters';
+
+@Injectable()
+export class ExternalRentersService {
+
+  constructor(private store: Store<AppState>) {}
+
+  getExternalRenters(): Observable<ExternalRenters> {
+    return this.store.select(appState => appState.externalRenters);
+  }
+
+  getExternalRenter(externalRenterID: number): Observable<ExternalRenter> {
+    return this.store.select(appState => appState.externalRenters.results[externalRenterID]);
+  }
+
+  getShouldShowAddNew(): Observable<boolean> {
+    return this.store.select(appState => appState.externalRenters.showAddNew);
+  }
+}

--- a/src/store/external-renters/external-renters.actions.spec.ts
+++ b/src/store/external-renters/external-renters.actions.spec.ts
@@ -1,0 +1,51 @@
+import { TestData } from '../../test-data';
+import { createAction } from '../create-action';
+import { StoreMock } from '../../mocks';
+
+import { ExternalRentersActions } from './external-renters.actions';
+
+let instance: ExternalRentersActions = null;
+
+describe('ExternalRenters Actions', () => {
+
+  beforeEach(() => {
+    instance = new ExternalRentersActions((<any> new StoreMock));
+  });
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
+
+  it('dispatches action FETCH', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.fetchExternalRenters();
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ExternalRentersActions.FETCH));
+  });
+
+  it('dispatches action CREATE', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.createExternalRenter(TestData.externalRenter, TestData.pop);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ExternalRentersActions.CREATE, {
+      externalRenter: TestData.externalRenter,
+      pop: TestData.pop
+    }));
+  });
+
+  it('dispatches action UPDATE', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.updateExternalRenter(TestData.externalRenter);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ExternalRentersActions.UPDATE, TestData.externalRenter));
+  });
+
+  it('dispatches action DELETE', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.deleteExternalRenter(TestData.externalRenter.externalRenterID);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ExternalRentersActions.DELETE, TestData.externalRenter.externalRenterID));
+  });
+
+  it('dispatches action FILTER', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.filterExternalRenters(TestData.queryText);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ExternalRentersActions.FILTER, TestData.queryText));
+  });
+});

--- a/src/store/external-renters/external-renters.actions.ts
+++ b/src/store/external-renters/external-renters.actions.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { type } from '../../utils';
+
+import { createAction } from '../create-action';
+import { AppState } from '../../models/app-state';
+
+@Injectable()
+export class ExternalRentersActions {
+
+  static FETCH = type('[External Renters] Fetch');
+  static FETCH_SUCCESS = type('[External Renters] Fetch Success');
+  static FETCH_FAIL = type('[External Renters] Fetch Fail');
+
+  static CREATE = type('[External Renters] Create');
+  static CREATE_SUCCESS = type('[External Renters] Create Success');
+  static CREATE_FAIL = type('[External Renters] Create Fail');
+
+  static UPDATE = type('[External Renters] Update');
+  static UPDATE_SUCCESS = type('[External Renters] Update Success');
+  static UPDATE_FAIL = type('[External Renters] Update Fail');
+
+  static DELETE = type('[External Renters] Delete');
+  static DELETE_SUCCESS = type('[External Renters] Delete Success');
+  static DELETE_FAIL = type('[External Renters] Delete Fail');
+
+  static FILTER = type('[External Renters] Filter');
+
+  constructor(
+    private store: Store<AppState>
+  ) {}
+
+  fetchExternalRenters() {
+    this.store.dispatch(createAction(ExternalRentersActions.FETCH));
+  }
+
+  // pop determines whether the nav should poped after the brand is created.
+  createExternalRenter(externalRenter: any, pop: boolean = false) {
+    this.store.dispatch(createAction(ExternalRentersActions.CREATE, { externalRenter, pop }));
+  }
+
+  updateExternalRenter(externalRenter: any) {
+    this.store.dispatch(createAction(ExternalRentersActions.UPDATE, externalRenter));
+  }
+
+  deleteExternalRenter(externalRenterID: number) {
+    this.store.dispatch(createAction(ExternalRentersActions.DELETE, externalRenterID));
+  }
+
+  filterExternalRenters(text: string) {
+    this.store.dispatch(createAction(ExternalRentersActions.FILTER, text));
+  }
+}

--- a/src/store/external-renters/external-renters.effects.spec.ts
+++ b/src/store/external-renters/external-renters.effects.spec.ts
@@ -1,0 +1,203 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { EffectsRunner, EffectsTestingModule } from '@ngrx/effects/testing';
+import { TestData } from '../../test-data';
+import { createAction } from '../create-action';
+import { ExternalRenterData } from '../../providers/external-renter-data';
+import { ExternalRenterDataMock } from '../../mocks';
+
+import { ExternalRentersEffects } from './external-renters.effects';
+import { ExternalRentersActions } from './external-renters.actions';
+import { AppActions } from '../app/app.actions';
+import { LayoutActions } from '../layout/layout.actions';
+import { Messages } from '../../constants';
+
+let instance: ExternalRentersEffects = null;
+let runner: EffectsRunner = null;
+
+describe('ExternalRenters Effects', () => {
+
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      EffectsTestingModule
+    ],
+    providers: [
+      ExternalRentersEffects,
+      { provide: ExternalRenterData, useClass: ExternalRenterDataMock }
+    ]
+  }));
+
+  beforeEach(inject([
+      EffectsRunner, ExternalRentersEffects
+    ],
+    (_runner, _instance) => {
+      runner = _runner;
+      instance = _instance;
+    }
+  ));
+
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
+
+  it('fetches external renters', () => {
+    instance.externalRenterData.externalRenters = TestData.externalRenters;
+
+    runner.queue(createAction(ExternalRentersActions.FETCH));
+
+    instance.fetch$.subscribe(
+      res => expect(res).toEqual(createAction(ExternalRentersActions.FETCH_SUCCESS, TestData.externalRenters))
+      err => fail(err)
+    );
+  });
+
+  it('returns error if fetch fails', () => {
+    instance.externalRenterData.resolve = false;
+
+    runner.queue(createAction(ExternalRentersActions.FETCH));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.FETCH_FAIL, TestData.error),
+      createAction(AppActions.SHOW_MESSAGE, TestData.error.message)
+    ];
+    instance.fetch$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('creates an external renter', () => {
+    runner.queue(createAction(ExternalRentersActions.CREATE, {
+      name: TestData.externalRenter.name,
+      pop: false
+    }));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.CREATE_SUCCESS, TestData.response),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+      createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
+    ];
+
+    instance.create$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('creates an external renter and pops nav', () => {
+    runner.queue(createAction(ExternalRentersActions.CREATE, {
+      name: TestData.externalRenter.name,
+      pop: true
+    }));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.CREATE_SUCCESS, TestData.response),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+      createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
+      createAction(AppActions.POP_NAV)
+    ];
+
+    instance.create$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('returns error if create fails', () => {
+    instance.externalRenterData.resolve = false;
+
+    runner.queue(createAction(ExternalRentersActions.CREATE, {
+      name: TestData.externalRenter.name,
+      pop: true
+    }));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.CREATE_FAIL, TestData.error),
+      createAction(AppActions.SHOW_MESSAGE, TestData.error.message),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+    ];
+    instance.create$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('updates an external renter', () => {
+    runner.queue(createAction(ExternalRentersActions.UPDATE, TestData.externalRenter));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.UPDATE_SUCCESS, TestData.response),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+      createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterEdited),
+      createAction(AppActions.POP_NAV)
+    ];
+
+    instance.update$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('returns error if update fails', () => {
+    instance.externalRenterData.resolve = false;
+
+    runner.queue(createAction(ExternalRentersActions.UPDATE, TestData.externalRenter));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.UPDATE_FAIL, TestData.error),
+      createAction(AppActions.SHOW_MESSAGE, TestData.error.message),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+    ];
+    instance.update$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('deletes an external renter', () => {
+    runner.queue(createAction(ExternalRentersActions.DELETE, TestData.externalRenter.externalRenterID));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.DELETE_SUCCESS, TestData.response),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+      createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterDeleted),
+      createAction(AppActions.POP_NAV)
+    ];
+
+    instance.delete$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+
+  it('returns error if delete fails', () => {
+    instance.externalRenterData.resolve = false;
+
+    runner.queue(createAction(ExternalRentersActions.DELETE, TestData.externalRenter.externalRenterID));
+
+    let performedActions = [];
+    const expectedResult = [
+      createAction(ExternalRentersActions.DELETE_FAIL, TestData.error),
+      createAction(AppActions.SHOW_MESSAGE, TestData.error.message),
+      createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+    ];
+    instance.delete$.take(expectedResult.length).subscribe(
+      res => performedActions.push(res),
+      err => fail(err),
+      () => expect(performedActions).toEqual(expectedResult)
+    );
+  });
+});

--- a/src/store/external-renters/external-renters.effects.ts
+++ b/src/store/external-renters/external-renters.effects.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect } from '@ngrx/effects';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+import { createAction } from '../create-action';
+import { ExternalRentersActions } from './external-renters.actions';
+import { AppActions } from '../app/app.actions';
+import { ExternalRenterData } from '../../providers/external-renter-data';
+import { LayoutActions } from '../layout/layout.actions';
+import { Messages } from '../../constants';
+
+@Injectable()
+export class ExternalRentersEffects {
+  constructor(
+    public actions$: Actions,
+    public externalRenterData: ExternalRenterData
+  ) {}
+
+  /**
+   * Fetches external renters.
+   */
+  @Effect()
+  fetch$ = this.actions$
+    .ofType(ExternalRentersActions.FETCH)
+    .mergeMap(action => this.externalRenterData.getExternalRenters()
+      .map(res => createAction(ExternalRentersActions.FETCH_SUCCESS, res))
+      .catch(err => Observable.of(
+        createAction(ExternalRentersActions.FETCH_FAIL, err),
+        createAction(AppActions.SHOW_MESSAGE, err.message)
+      ))
+    );
+
+  /**
+   * Creates external renter.
+   */
+  @Effect()
+  create$ = this.actions$
+    .ofType(ExternalRentersActions.CREATE)
+    .mergeMap(action => this.externalRenterData.createExternalRenter(action.payload.externalRenter)
+      .concatMap(res => {
+        let success = [
+          createAction(ExternalRentersActions.CREATE_SUCCESS, res),
+          createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+          createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
+        ];
+
+        if (action.payload.pop) {
+          success.push(createAction(AppActions.POP_NAV));
+        }
+
+        return success;
+      })
+      .catch(err => Observable.of(
+        createAction(ExternalRentersActions.CREATE_FAIL, err),
+        createAction(AppActions.SHOW_MESSAGE, err.message),
+        createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+      ))
+    );
+
+  /**
+   * Updates external renter.
+   */
+  @Effect()
+  update$ = this.actions$
+    .ofType(ExternalRentersActions.UPDATE)
+    .mergeMap(action => this.externalRenterData.updateExternalRenter(action.payload, action.payload.externalRenterID)
+      .concatMap(res => [
+        createAction(ExternalRentersActions.UPDATE_SUCCESS, res),
+        createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+        createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterEdited),
+        createAction(AppActions.POP_NAV)
+      ])
+      .catch(err => Observable.of(
+        createAction(ExternalRentersActions.UPDATE_FAIL, err),
+        createAction(AppActions.SHOW_MESSAGE, err.message),
+        createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+      ))
+    );
+
+  /**
+   * Deletes external renter.
+   */
+  @Effect()
+  delete$ = this.actions$
+    .ofType(ExternalRentersActions.DELETE)
+    .mergeMap(action => this.externalRenterData.deleteExternalRenter(action.payload)
+      .concatMap(res => [
+        createAction(ExternalRentersActions.DELETE_SUCCESS, res),
+        createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+        createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterDeleted),
+        createAction(AppActions.POP_NAV)
+      ])
+      .catch(err => Observable.of(
+        createAction(ExternalRentersActions.DELETE_FAIL, err),
+        createAction(AppActions.SHOW_MESSAGE, err.message),
+        createAction(LayoutActions.HIDE_LOADING_MESSAGE)
+      ))
+    );
+}

--- a/src/store/external-renters/external-renters.reducer.ts
+++ b/src/store/external-renters/external-renters.reducer.ts
@@ -1,0 +1,61 @@
+import { Action } from '@ngrx/store';
+
+import { ExternalRentersActions } from './external-renters.actions';
+import { ExternalRenters } from '../../models/external-renters';
+
+const initialState = {
+  results: {},
+  filtered: [],
+  showAddNew: false,
+  showLoadingSpinner: false
+};
+
+export function externalRentersReducer(externalRenters: ExternalRenters = initialState, action: Action): ExternalRenters {
+  switch (action.type) {
+    case ExternalRentersActions.FETCH:
+      return { ...externalRenters, showLoadingSpinner: true };
+    case ExternalRentersActions.FETCH_SUCCESS:
+      return {
+        ...externalRenters,
+        results: Object.assign({},
+          externalRenters.results,
+          action.payload.results.reduce((obj, externalRenter) => {
+            obj[externalRenter.externalRenterID] = externalRenter;
+            return obj;
+          }, {})
+        ),
+        filtered: action.payload.results,
+        showAddNew: false,
+        showLoadingSpinner: false
+      };
+    case ExternalRentersActions.CREATE_SUCCESS:
+    case ExternalRentersActions.UPDATE_SUCCESS:
+      return {
+        ...externalRenters,
+        results: {
+          ...externalRenters.results,
+          [action.payload.externalRenterID]: action.payload
+        }
+      };
+    case ExternalRentersActions.DELETE_SUCCESS:
+      const results = Object.assign({}, externalRenters.results);
+      delete results[action.payload.id];
+      return {
+        ...externalRenters,
+        results
+      };
+    case ExternalRentersActions.FILTER:
+      const filtered = Object.keys(externalRenters.results)
+        .map((key) => externalRenters.results[key])
+        .filter(externalRenter => externalRenter.name.toLowerCase().indexOf(action.payload.toLowerCase()) > -1);
+
+      return Object.assign({}, externalRenters, {
+        filtered: filtered,
+        showAddNew: !filtered.find(externalRenter => {
+          return externalRenter.name.toLowerCase() === action.payload.toLowerCase() || action.payload === '';
+        })
+      });
+    default:
+      return externalRenters;
+  }
+}

--- a/src/store/root-reducer.ts
+++ b/src/store/root-reducer.ts
@@ -7,6 +7,7 @@ import { brandsReducer } from './brands/brands.reducer';
 import { modelsReducer } from './models/models.reducer';
 import { categoriesReducer } from './categories/categories.reducer';
 import { layoutReducer } from './layout/layout.reducer';
+import { externalRentersReducer } from './external-renters/external-renters.reducer';
 
 export const rootReducer = {
   user: userReducer,
@@ -17,5 +18,6 @@ export const rootReducer = {
   brands: brandsReducer,
   models: modelsReducer,
   categories: categoriesReducer,
-  layout: layoutReducer
+  layout: layoutReducer,
+  externalRenters: externalRentersReducer
 };

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -567,8 +567,61 @@ export class TestData {
     },
     layout: {
       loadingMessage: 'Please wait...'
+    },
+    externalRenters: {
+      results: {
+        [1]: {
+          externalRenterID: 1,
+          name: 'Luke',
+          email: 'luke@email.com',
+          phone: '1234567890'
+        },
+        [2]: {
+          externalRenterID: 2,
+          name: 'Anakin',
+          email: 'anakin@email.com',
+          phone: '0987654321'
+        },
+        [3]: {
+          externalRenterID: 3,
+          name: 'Obi Wan',
+          email: 'obiwan@email.com',
+          phone: '1029384756'
+        }
+      },
+      showLoadingSpinner: false
     }
   };
 
   public static pop = true;
+
+  public static externalRenter = {
+    externalRenterID: 1,
+    name: 'Luke',
+    email: 'luke@email.com',
+    phone: '1234567890'
+  };
+
+  public static externalRenters = {
+    results: [
+      {
+        externalRenterID: 1,
+        name: 'Luke',
+        email: 'luke@email.com',
+        phone: '1234567890'
+      },
+      {
+        externalRenterID: 2,
+        name: 'Anakin',
+        email: 'anakin@email.com',
+        phone: '0987654321'
+      },
+      {
+        externalRenterID: 3,
+        name: 'Obi Wan',
+        email: 'obiwan@email.com',
+        phone: '1029384756'
+      }
+    ]
+  };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -47,6 +47,7 @@ import {
   LoadingMock,
   BrandsActionsMock,
   CategoriesActionsMock,
+  ExternalRentersActionsMock,
   ItemsActionsMock,
   KitModelsActionsMock,
   KitsActionsMock,
@@ -56,6 +57,7 @@ import {
   UserActionsMock,
   BrandsServiceMock,
   CategoriesServiceMock,
+  ExternalRentersServiceMock,
   ItemsServiceMock,
   KitModelsServiceMock,
   KitsServiceMock,
@@ -68,6 +70,7 @@ import {
 } from './mocks';
 import { BrandsActions } from './store/brands/brands.actions';
 import { CategoriesActions } from './store/categories/categories.actions';
+import { ExternalRentersActions } from './store/external-renters/external-renters.actions';
 import { ItemsActions } from './store/items/items.actions';
 import { KitModelsActions } from './store/kit-models/kit-models.actions';
 import { KitsActions } from './store/kits/kits.actions';
@@ -77,6 +80,7 @@ import { OrganizationActions } from './store/organization/organization.actions';
 import { UserActions } from './store/user/user.actions';
 import { BrandsService } from './services/brands.service';
 import { CategoriesService } from './services/categories.service';
+import { ExternalRentersService } from './services/external-renters.service';
 import { ItemsService } from './services/items.service';
 import { KitModelsService } from './services/kit-models.service';
 import { KitsService } from './services/kits.service';
@@ -150,6 +154,7 @@ export class TestUtils {
         { provide: LoadingController, useClass: LoadingMock },
         { provide: BrandsActions, useClass: BrandsActionsMock },
         { provide: CategoriesActions, useClass: CategoriesActionsMock },
+        { provide: ExternalRentersActions, useClass: ExternalRentersActionsMock },
         { provide: ItemsActions, useClass: ItemsActionsMock },
         { provide: KitModelsActions, useClass: KitModelsActionsMock },
         { provide: KitsActions, useClass: KitsActionsMock },
@@ -159,6 +164,7 @@ export class TestUtils {
         { provide: UserActions, useClass: UserActionsMock },
         { provide: BrandsService, useClass: BrandsServiceMock },
         { provide: CategoriesService, useClass: CategoriesServiceMock },
+        { provide: ExternalRentersService, useClass: ExternalRentersServiceMock },
         { provide: ItemsService, useClass: ItemsServiceMock },
         { provide: KitModelsService, useClass: KitModelsServiceMock },
         { provide: KitsService, useClass: KitsServiceMock },


### PR DESCRIPTION
Closes #418 

Choosing external renters works the same way than choosing a brand, model, or category when editing an item. When users create a new external renter from the modal, they can only enter the same (similar again to brand, model, and category).

This was done because, in order to enter more info (email and phone number), we would have to push the `EditExternalRenterPage` onto the nav, but this is not possible from a modal. I think this is an appropriate compromise since the name is the only required field, and users can enter the other info later if they want by editing the external renter. It also makes the code much simpler, and increases consistency.