### PR TITLE
Revert to using es2015 syntax

### DIFF
--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -95,10 +95,10 @@ export class ItemPage {
 
       // Transform the values from the form to an array
       let itemCustomFieldsList = [];
-      Object.entries(form.value).map(input => {
+      Object.keys(form.value).map(key => {
         itemCustomFieldsList.push({
-          customFieldID: input[0],
-          value: input[1]
+          customFieldID: key,
+          value: form.value[key]
         });
       });
 

--- a/src/pipes/map-to-iterable.pipe.ts
+++ b/src/pipes/map-to-iterable.pipe.ts
@@ -8,6 +8,6 @@ export class MapToIterablePipe {
     if (!map) {
       return null;
     }
-    return Object.values(map);
+    return Object.keys(map).map(key => map[key]);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "experimentalDecorators": true,
     "lib": [
       "dom",
-      "es2017"
+      "es2015"
     ],
     "module": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
The app, when run on an Android emulator, wasn't recognizing the es2017 syntax (`Object.values` and `Object.entries`), so we have to revert to using ES2017 syntax.

This is a very easy fix and probably isn't worth spending too much time trying to figure out the compatibility issue between Ionic/Cordova and the TypeScript compiler.