### PR TITLE
hotfix/add marketing icon

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -57,6 +57,7 @@
         <icon height="29" src="resources/ios/icon/icon-small.png" width="29" />
         <icon height="58" src="resources/ios/icon/icon-small@2x.png" width="58" />
         <icon height="87" src="resources/ios/icon/icon-small@3x.png" width="87" />
+        <icon height="1024" src="resources/ios/icon.png" width="1024" />
         <splash height="1136" src="resources/ios/splash/Default-568h@2x~iphone.png" width="640" />
         <splash height="1334" src="resources/ios/splash/Default-667h.png" width="750" />
         <splash height="2208" src="resources/ios/splash/Default-736h.png" width="1242" />
@@ -95,11 +96,11 @@
     <icon src="resources/android/icon/drawable-xhdpi-icon.png" />
     <plugin name="cordova-custom-config" spec="~3.1.4" />
     <engine name="android" spec="~6.1.2" />
-    <engine name="ios" spec="~4.3.1" />
     <plugin name="cordova-plugin-x-toast" spec="~2.6.0" />
     <plugin name="phonegap-plugin-barcodescanner" spec="~6.0.8">
         <variable name="CAMERA_USAGE_DESCRIPTION" value="The app needs to access your camera to scan barcodes" />
     </plugin>
     <plugin name="cordova-plugin-inappbrowser" spec="~1.7.1" />
     <plugin name="cordova-plugin-wkwebview-engine" spec="^2.2.0" />
+    <engine name="ios" spec="~4.5.1" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,10 +2681,219 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
       "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
     },
+    "cordova-android": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-6.1.2.tgz",
+      "integrity": "sha1-lgZzmhFPCjf0kFPjZMlthPtGK/g=",
+      "requires": {
+        "cordova-common": "1.5.1",
+        "elementtree": "0.1.6",
+        "nopt": "3.0.6",
+        "properties-parser": "0.2.3",
+        "q": "1.4.1",
+        "shelljs": "0.5.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "ansi": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "big-integer": {
+          "version": "1.6.16",
+          "bundled": true
+        },
+        "bplist-parser": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "big-integer": "1.6.16"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cordova-common": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "bplist-parser": "0.1.1",
+            "cordova-registry-mapper": "1.1.15",
+            "elementtree": "0.1.6",
+            "glob": "5.0.15",
+            "minimatch": "3.0.3",
+            "osenv": "0.1.3",
+            "plist": "1.2.0",
+            "q": "1.4.1",
+            "semver": "5.3.0",
+            "shelljs": "0.5.3",
+            "underscore": "1.8.3",
+            "unorm": "1.4.1"
+          }
+        },
+        "cordova-registry-mapper": {
+          "version": "1.1.15",
+          "bundled": true
+        },
+        "elementtree": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "sax": "0.3.5"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "plist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "util-deprecate": "1.0.2",
+            "xmlbuilder": "4.0.0",
+            "xmldom": "0.1.22"
+          }
+        },
+        "properties-parser": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xmlbuilder": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "3.10.1"
+          }
+        },
+        "xmldom": {
+          "version": "0.1.22",
+          "bundled": true
+        }
+      }
+    },
     "cordova-custom-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cordova-custom-config/-/cordova-custom-config-4.0.2.tgz",
-      "integrity": "sha1-duiKQK0hN1QGny5kmB6RZ6WX3+4=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cordova-custom-config/-/cordova-custom-config-3.1.4.tgz",
+      "integrity": "sha1-xDwy3DsRR972U2chtxORr0goo20=",
       "requires": {
         "colors": "1.1.2",
         "elementtree": "0.1.7",
@@ -2694,6 +2903,349 @@
         "tostr": "0.1.0",
         "xcode": "0.8.9"
       }
+    },
+    "cordova-ios": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-4.5.1.tgz",
+      "integrity": "sha1-0XshBIx4LnUZD40Fp5g8evNMtYU=",
+      "requires": {
+        "cordova-common": "2.1.0",
+        "ios-sim": "6.1.2",
+        "nopt": "3.0.6",
+        "plist": "1.2.0",
+        "q": "1.5.0",
+        "shelljs": "0.5.3",
+        "xcode": "0.9.3",
+        "xml-escape": "1.1.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ansi": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "big-integer": {
+          "version": "1.6.25",
+          "bundled": true
+        },
+        "bplist-creator": {
+          "version": "0.0.7",
+          "bundled": true,
+          "requires": {
+            "stream-buffers": "2.2.0"
+          }
+        },
+        "bplist-parser": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "big-integer": "1.6.25"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cordova-common": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "bplist-parser": "0.1.1",
+            "cordova-registry-mapper": "1.1.15",
+            "elementtree": "0.1.6",
+            "glob": "5.0.15",
+            "minimatch": "3.0.4",
+            "osenv": "0.1.4",
+            "plist": "1.2.0",
+            "q": "1.5.0",
+            "semver": "5.4.1",
+            "shelljs": "0.5.3",
+            "underscore": "1.8.3",
+            "unorm": "1.4.1"
+          }
+        },
+        "cordova-registry-mapper": {
+          "version": "1.1.15",
+          "bundled": true
+        },
+        "elementtree": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "sax": "0.3.5"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ios-sim": {
+          "version": "6.1.2",
+          "bundled": true,
+          "requires": {
+            "bplist-parser": "0.0.6",
+            "nopt": "1.0.9",
+            "plist": "1.2.0",
+            "simctl": "1.1.1"
+          },
+          "dependencies": {
+            "bplist-parser": {
+              "version": "0.0.6",
+              "bundled": true
+            },
+            "nopt": {
+              "version": "1.0.9",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.0"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pegjs": {
+          "version": "0.10.0",
+          "bundled": true
+        },
+        "plist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "util-deprecate": "1.0.2",
+            "xmlbuilder": "4.0.0",
+            "xmldom": "0.1.27"
+          }
+        },
+        "q": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "sax": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "simctl": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "shelljs": "0.2.6",
+            "tail": "0.4.0"
+          },
+          "dependencies": {
+            "shelljs": {
+              "version": "0.2.6",
+              "bundled": true
+            }
+          }
+        },
+        "simple-plist": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "bplist-creator": "0.0.7",
+            "bplist-parser": "0.1.1",
+            "plist": "2.0.1"
+          },
+          "dependencies": {
+            "base64-js": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "plist": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "base64-js": "1.1.2",
+                "xmlbuilder": "8.2.2",
+                "xmldom": "0.1.27"
+              }
+            },
+            "xmlbuilder": {
+              "version": "8.2.2",
+              "bundled": true
+            }
+          }
+        },
+        "stream-buffers": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "tail": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xcode": {
+          "version": "0.9.3",
+          "bundled": true,
+          "requires": {
+            "pegjs": "0.10.0",
+            "simple-plist": "0.2.1",
+            "uuid": "3.0.1"
+          }
+        },
+        "xml-escape": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "xmlbuilder": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "3.10.1"
+          }
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "bundled": true
+        }
+      }
+    },
+    "cordova-plugin-device": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-1.1.4.tgz",
+      "integrity": "sha1-1f50cSBp0D9tOG7wvTIbOr0NONw="
+    },
+    "cordova-plugin-inappbrowser": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-inappbrowser/-/cordova-plugin-inappbrowser-1.7.1.tgz",
+      "integrity": "sha1-Q1tD9ZH+e/qV6pjb4ABIQf5ZulE="
+    },
+    "cordova-plugin-ionic-wkwebview-engine": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-wkwebview-engine/-/cordova-plugin-ionic-wkwebview-engine-1.1.4.tgz",
+      "integrity": "sha512-h5jWVgqt465U/tHl2ykaDh6FVC1C7z6dGVnS3LnAU0PVUB6nfuxm2cTiVY9b3zg94+ijNDxOs8L7bmKtpT15ow=="
+    },
+    "cordova-plugin-splashscreen": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-splashscreen/-/cordova-plugin-splashscreen-4.0.3.tgz",
+      "integrity": "sha1-dzzRNjwfO6y5kBZj6eN5PdPgoZ0="
+    },
+    "cordova-plugin-statusbar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-2.2.1.tgz",
+      "integrity": "sha1-tRwOGqsrpm7bd85SvyuT/IBsjHA="
+    },
+    "cordova-plugin-whitelist": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.1.tgz",
+      "integrity": "sha1-n9Hbf9bJVpUdNHcc3Nl/Zs7VFt8="
+    },
+    "cordova-plugin-x-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-x-toast/-/cordova-plugin-x-toast-2.6.0.tgz",
+      "integrity": "sha1-R3i+y2HjbIlRCRoHWFDCje2PVqU="
     },
     "core-js": {
       "version": "2.5.0",
@@ -6728,6 +7280,11 @@
         }
       }
     },
+    "ionic-plugin-keyboard": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ionic-plugin-keyboard/-/ionic-plugin-keyboard-2.2.1.tgz",
+      "integrity": "sha1-8qnhabvptVIkADR8n9bTRn7j+hI="
+    },
     "ionicons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-3.0.0.tgz",
@@ -9062,6 +9619,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
+    },
+    "phonegap-plugin-barcodescanner": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/phonegap-plugin-barcodescanner/-/phonegap-plugin-barcodescanner-6.0.8.tgz",
+      "integrity": "sha1-2VxyuKrhaD9jD7wMFt1R7efuROs="
     },
     "pify": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,324 +789,6 @@
         }
       }
     },
-    "@ionic/cli-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@ionic/cli-utils/-/cli-utils-1.12.0.tgz",
-      "integrity": "sha512-N7/pKa+kiOjtfdc//Gv8vCbsRftenHjs4tIcz5VTW8VM7B9QIu8Ylcuq2JTsKJJoXiFreShku9KPqPm4bpbpSg==",
-      "dev": true,
-      "requires": {
-        "archiver": "2.0.3",
-        "basic-auth": "1.1.0",
-        "body-parser": "1.18.2",
-        "chalk": "2.1.0",
-        "chokidar": "1.7.0",
-        "ci-info": "1.1.1",
-        "cross-spawn": "5.1.0",
-        "dargs": "5.1.0",
-        "diff": "3.3.1",
-        "elementtree": "0.1.7",
-        "express": "4.15.4",
-        "inquirer": "3.3.0",
-        "leek": "0.0.24",
-        "lodash": "4.17.4",
-        "minimist": "1.2.0",
-        "ncp": "2.0.0",
-        "opn": "5.1.0",
-        "proxy-middleware": "0.15.0",
-        "semver": "5.4.1",
-        "slice-ansi": "1.0.0",
-        "ssh-config": "1.1.3",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "superagent": "3.6.3",
-        "tar": "2.2.1",
-        "tiny-lr": "1.0.5",
-        "tslib": "1.7.1",
-        "uuid": "3.1.0",
-        "wrap-ansi": "3.0.1",
-        "ws": "3.2.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "cookiejar": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "formidable": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.1.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.1.0",
-            "external-editor": "2.0.4",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "opn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-          "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
-          "dev": true,
-          "requires": {
-            "is-wsl": "1.1.0"
-          }
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "superagent": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.6.3.tgz",
-          "integrity": "sha512-GjsfCFijfjqoz2tRiStSOoTdy7gNZOcK3ar4zONP9D8dXQWE+Qg7cbePHimRpapo06WUvoU3dmgi2e4q+sab5A==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
-            "debug": "3.1.0",
-            "extend": "3.0.0",
-            "form-data": "2.3.1",
-            "formidable": "1.1.1",
-            "methods": "1.1.2",
-            "mime": "1.4.1",
-            "qs": "6.5.1",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "tiny-lr": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.0.5.tgz",
-          "integrity": "sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg==",
-          "dev": true,
-          "requires": {
-            "body": "5.1.0",
-            "debug": "2.6.9",
-            "faye-websocket": "0.10.0",
-            "livereload-js": "2.2.2",
-            "object-assign": "4.1.1",
-            "qs": "6.5.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "ultron": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-          "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "ws": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.2.0.tgz",
-          "integrity": "sha512-hTS3mkXm/j85jTQOIcwVz3yK3up9xHgPtgEhDBOH3G18LDOZmSAG1omJeXejLKJakx+okv8vS1sopgs7rw0kVw==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.0"
-          }
-        }
-      }
-    },
     "@ionic/cloud": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@ionic/cloud/-/cloud-0.16.0.tgz",
@@ -1138,15 +820,6 @@
         "rxjs": "5.4.0",
         "snake-case": "2.1.0",
         "ws": "1.1.4"
-      }
-    },
-    "@ionic/discover": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@ionic/discover/-/discover-0.3.1.tgz",
-      "integrity": "sha512-IM2nju07Ip+5j9BbCh+AFvi2BRR6Lanvvzj/VJn2DGXXaK7znmlLrlSpzOp+R+GH4FijAmFpyWXn1sF5Uhkiyg==",
-      "dev": true,
-      "requires": {
-        "netmask": "1.0.6"
       }
     },
     "@ionic/storage": {
@@ -1372,7 +1045,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -1391,66 +1064,8 @@
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
-    },
-    "archiver": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.0.3.tgz",
-      "integrity": "sha1-tDYLtYSvFDeZGUJxbyHXxSPR270=",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.5.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "readable-stream": "2.3.3",
-        "tar-stream": "1.5.4",
-        "walkdir": "0.0.11",
-        "zip-stream": "1.2.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "archiver-utils": {
       "version": "1.3.0",
@@ -1517,7 +1132,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1532,7 +1147,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1567,7 +1182,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-find-index": {
@@ -1803,7 +1418,7 @@
     "babylon": {
       "version": "6.17.4",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
       "dev": true
     },
     "backo2": {
@@ -1832,7 +1447,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
     "base64id": {
@@ -1931,7 +1546,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body": {
@@ -2044,7 +1659,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -2059,7 +1674,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -2076,7 +1691,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -2417,7 +2032,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -2594,7 +2209,7 @@
             "async": {
               "version": "2.5.0",
               "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-              "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+              "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
               "dev": true,
               "requires": {
                 "lodash": "4.17.4"
@@ -2781,7 +2396,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "common-tags": {
@@ -2937,7 +2552,7 @@
     "configstore": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -3335,7 +2950,7 @@
     "crypto-browserify": {
       "version": "3.11.1",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha1-lIlF78Z1ekANbl5a9HGU0QBkJ58=",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -3638,7 +3253,7 @@
     "diff": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha1-BWaVFQ16qTI3yn43isOxaCt5Y7k=",
+      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
       "dev": true
     },
     "diffie-hellman": {
@@ -3782,7 +3397,7 @@
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
@@ -4416,7 +4031,7 @@
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk=",
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
           "dev": true
         }
       }
@@ -4461,7 +4076,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -4574,7 +4189,7 @@
     "finalhandler": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha1-GFdPLnxLmLiuOyMMIfIB8xvbP7c=",
+      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -4706,7 +4321,7 @@
     "fsevents": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5856,7 +5471,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -5906,7 +5521,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globule": {
@@ -6071,7 +5686,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -6116,7 +5731,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "hpack.js": {
@@ -6140,7 +5755,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -6155,7 +5770,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -6178,7 +5793,7 @@
     "html-minifier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.3.tgz",
-      "integrity": "sha1-SideOxoWY5q7ebTBEZH/DQ/PGrk=",
+      "integrity": "sha512-iKRzQQDuTCsq0Ultbi/mfJJnR0D3AdZKTq966Gsp92xkmAPCV4Xi08qhJ0Dl3ZAWemSgJ7qZK+UsZc0gFqK6wg==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
@@ -6331,7 +5946,7 @@
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI=",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
       "dev": true
     },
     "icss-replace-symbols": {
@@ -6450,7 +6065,7 @@
     "inquirer": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha1-Bs6w9UD0XKVIwX1oQJWYeCZfoXU=",
+      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
@@ -6478,7 +6093,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -6487,7 +6102,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6513,7 +6128,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6542,21 +6157,90 @@
       "dev": true
     },
     "ionic": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/ionic/-/ionic-3.12.0.tgz",
-      "integrity": "sha512-a2W91OzjrShfxQ1DLe79TG5uNEdVyFjT2y6aHj6aE43vaP4N1+xg64TH26W7APUPqz9CvGURd6JzNnGh+5wQOg==",
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/ionic/-/ionic-3.13.2.tgz",
+      "integrity": "sha512-YbWW0UuZS7nidz9IQh2TIH21YPJNlSZAju23qUFFM4XSK/SMZJPWvaI9tLHJ9PoFqtcakNmkug29iDqwLOnTuA==",
       "dev": true,
       "requires": {
-        "@ionic/cli-utils": "1.12.0",
-        "@ionic/discover": "0.3.1",
-        "chalk": "2.1.0",
+        "@ionic/cli-utils": "1.13.1",
+        "@ionic/discover": "0.3.3",
+        "chalk": "2.2.0",
         "opn": "5.1.0",
         "os-name": "2.0.1",
         "rimraf": "2.6.2",
         "semver": "5.4.1",
-        "tslib": "1.7.1"
+        "tslib": "1.8.0"
       },
       "dependencies": {
+        "@ionic/cli-utils": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@ionic/cli-utils/-/cli-utils-1.13.1.tgz",
+          "integrity": "sha512-r6yTJ0EmC5MDGqQsR1ItGSLOHCssLRISpqECBbDtINrBa36fdDigcspzEJAJ9xXoWwyXbY+suTtvc5Jb7YFZNQ==",
+          "dev": true,
+          "requires": {
+            "archiver": "2.1.0",
+            "basic-auth": "1.1.0",
+            "body-parser": "1.18.2",
+            "chalk": "2.2.0",
+            "chokidar": "1.7.0",
+            "ci-info": "1.1.1",
+            "cross-spawn": "5.1.0",
+            "dargs": "5.1.0",
+            "diff": "3.4.0",
+            "elementtree": "0.1.7",
+            "express": "4.16.2",
+            "inquirer": "3.3.0",
+            "leek": "0.0.24",
+            "lodash": "4.17.4",
+            "minimist": "1.2.0",
+            "ncp": "2.0.0",
+            "opn": "5.1.0",
+            "proxy-middleware": "0.15.0",
+            "semver": "5.4.1",
+            "slice-ansi": "1.0.0",
+            "ssh-config": "1.1.3",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "superagent": "3.7.0",
+            "tar": "2.2.1",
+            "tiny-lr": "1.0.5",
+            "tslib": "1.8.0",
+            "uuid": "3.1.0",
+            "wrap-ansi": "3.0.1",
+            "ws": "3.2.0"
+          }
+        },
+        "@ionic/discover": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@ionic/discover/-/discover-0.3.3.tgz",
+          "integrity": "sha512-xciPTCEMYHv6sT7e4NwrAGkVQ8prj1NK9xO2z7/MoB+/HhREDsYDreNjU0lZF6G4X/91HcNNPC439D2WkAGd1w==",
+          "dev": true,
+          "requires": {
+            "netmask": "1.0.6"
+          }
+        },
+        "accepts": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+          "dev": true,
+          "requires": {
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -6566,22 +6250,243 @@
             "color-convert": "1.9.0"
           }
         },
-        "chalk": {
+        "archiver": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
+          "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
+          "dev": true,
+          "requires": {
+            "archiver-utils": "1.3.0",
+            "async": "2.5.0",
+            "buffer-crc32": "0.2.13",
+            "glob": "7.1.2",
+            "lodash": "4.17.4",
+            "readable-stream": "2.3.3",
+            "tar-stream": "1.5.4",
+            "zip-stream": "1.2.0"
+          }
+        },
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "chalk": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true
+        },
+        "cookiejar": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+          "dev": true
+        },
+        "express": {
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+          "dev": true,
+          "requires": {
+            "accepts": "1.3.4",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.0",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "2.0.2",
+            "qs": "6.5.1",
+            "range-parser": "1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.1",
+            "serve-static": "1.13.1",
+            "setprototypeof": "1.1.0",
+            "statuses": "1.3.1",
+            "type-is": "1.6.15",
+            "utils-merge": "1.0.1",
+            "vary": "1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "formidable": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+          "dev": true
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.2.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.1.0",
+            "external-editor": "2.0.4",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+          "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
         },
         "opn": {
           "version": "5.1.0",
@@ -6590,6 +6495,49 @@
           "dev": true,
           "requires": {
             "is-wsl": "1.1.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "proxy-addr": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+          "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+          "dev": true,
+          "requires": {
+            "forwarded": "0.1.2",
+            "ipaddr.js": "1.5.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -6601,13 +6549,158 @@
             "glob": "7.1.2"
           }
         },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "serve-static": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
+            "send": "0.16.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "superagent": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
+          "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "3.1.0",
+            "extend": "3.0.0",
+            "form-data": "2.3.1",
+            "formidable": "1.1.1",
+            "methods": "1.1.2",
+            "mime": "1.4.1",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.3"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "tiny-lr": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.0.5.tgz",
+          "integrity": "sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg==",
+          "dev": true,
+          "requires": {
+            "body": "5.1.0",
+            "debug": "2.6.9",
+            "faye-websocket": "0.10.0",
+            "livereload-js": "2.2.2",
+            "object-assign": "4.1.1",
+            "qs": "6.5.1"
+          }
+        },
+        "tslib": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
+          "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+          "dev": true
+        },
+        "ultron": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+          "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "dev": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "ws": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.2.0.tgz",
+          "integrity": "sha512-hTS3mkXm/j85jTQOIcwVz3yK3up9xHgPtgEhDBOH3G18LDOZmSAG1omJeXejLKJakx+okv8vS1sopgs7rw0kVw==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.0"
           }
         }
       }
@@ -6793,7 +6886,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "3.0.1"
       }
@@ -6923,7 +7016,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -6960,13 +7053,13 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-      "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+      "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "dev": true,
       "requires": {
         "append-transform": "0.4.0"
@@ -6990,7 +7083,7 @@
     "istanbul-lib-report": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
+      "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.1",
@@ -7002,7 +7095,7 @@
     "istanbul-lib-source-maps": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-      "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+      "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -7015,7 +7108,7 @@
     "istanbul-reports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-      "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
+      "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
       "dev": true,
       "requires": {
         "handlebars": "4.0.10"
@@ -7183,7 +7276,7 @@
     "jschardet": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k=",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
       "dev": true
     },
     "jsesc": {
@@ -7195,7 +7288,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
     "json-schema": {
@@ -7360,7 +7453,7 @@
     "karma-chrome-launcher": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
-      "integrity": "sha1-zxudBxNswY/iOTJ9JGVMPbw2is8=",
+      "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
         "fs-access": "1.0.1",
@@ -8053,7 +8146,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -8157,7 +8250,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -8172,7 +8265,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -8288,7 +8381,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -8443,7 +8536,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -8458,7 +8551,7 @@
             "string_decoder": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -8513,7 +8606,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -8561,7 +8654,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -8949,7 +9042,7 @@
     "pbkdf2": {
       "version": "3.0.13",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
-      "integrity": "sha1-w30pVTHnhrHaPj6tyEBCasywriU=",
+      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
       "dev": true,
       "requires": {
         "create-hash": "1.1.3",
@@ -9261,7 +9354,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -9270,7 +9363,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9298,7 +9391,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9319,7 +9412,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -9328,7 +9421,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9356,7 +9449,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9377,7 +9470,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -9386,7 +9479,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9414,7 +9507,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9435,7 +9528,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -9444,7 +9537,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9472,7 +9565,7 @@
         "supports-color": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9655,7 +9748,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9757,7 +9850,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -9798,7 +9891,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -9904,7 +9997,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -9919,7 +10012,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -10213,7 +10306,7 @@
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -10376,7 +10469,7 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha1-LpZJFZmpbN4bUV1WdKj3qRRSkmo=",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
       "dev": true
     },
     "run-async": {
@@ -10414,7 +10507,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "safe-json-parse": {
@@ -10449,7 +10542,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -10472,7 +10565,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "script-loader": {
@@ -10514,7 +10607,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "semver-diff": {
@@ -11011,7 +11104,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -11026,7 +11119,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -11094,7 +11187,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -11109,7 +11202,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -11136,7 +11229,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -11151,7 +11244,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -11167,7 +11260,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -11186,7 +11279,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -11201,7 +11294,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -11235,7 +11328,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -11578,7 +11671,7 @@
     "timers-browserify": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz",
-      "integrity": "sha1-Qf0L3JJqX+7cM6F6jh99SRkl9/w=",
+      "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
       "dev": true,
       "requires": {
         "global": "4.3.2",
@@ -11922,7 +12015,7 @@
     "uglify-js": {
       "version": "3.0.27",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
-      "integrity": "sha1-qX24yLprnbpOL4jYaqlUj6YyADQ=",
+      "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
@@ -12127,7 +12220,7 @@
     "url-loader": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha1-zI/qgse5Bud3cBklCGnlaemVwpU=",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -12228,7 +12321,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
     "v8flags": {
@@ -12305,18 +12398,12 @@
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha1-SCcoCvxC0OA1NnxKTjHurA0Tb3U=",
+      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "dev": true,
       "requires": {
         "ensure-posix-path": "1.0.2",
         "matcher-collection": "1.0.4"
       }
-    },
-    "walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
-      "dev": true
     },
     "watchpack": {
       "version": "1.4.0",
@@ -12332,7 +12419,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -12386,7 +12473,7 @@
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -12676,7 +12763,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -12691,7 +12778,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -12811,7 +12898,7 @@
     "write-file-atomic": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha1-F2n0tVHu3OQZ8FBd6uLiZ2NULTc=",
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "codeclimate-test-reporter": "^0.4.1",
     "codecov": "^1.0.1",
     "coveralls": "^2.13.3",
-    "ionic": "3.12.0",
+    "ionic": "3.13.2",
     "istanbul-instrumenter-loader": "^2.0.0",
     "jasmine-core": "^2.8.0",
     "jasmine-spec-reporter": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,24 @@
     "@ngrx/effects": "^2.0.3",
     "@ngrx/store": "^2.2.2",
     "angular2-jwt": "0.1.25",
-    "cordova-custom-config": "4.0.2",
+    "cordova-custom-config": "~3.1.4",
+    "cordova-ios": "4.5.1",
     "ionic-angular": "3.7.1",
     "ionicons": "3.0.0",
     "raven-js": "^3.18.1",
     "rxjs": "5.4.0",
     "sw-toolbox": "3.6.0",
-    "zone.js": "0.8.18"
+    "zone.js": "0.8.18",
+    "cordova-android": "~6.1.2",
+    "ionic-plugin-keyboard": "~2.2.1",
+    "cordova-plugin-whitelist": "1.3.1",
+    "cordova-plugin-statusbar": "2.2.1",
+    "cordova-plugin-device": "1.1.4",
+    "cordova-plugin-splashscreen": "~4.0.1",
+    "cordova-plugin-x-toast": "~2.6.0",
+    "phonegap-plugin-barcodescanner": "~6.0.8",
+    "cordova-plugin-inappbrowser": "~1.7.1",
+    "cordova-plugin-ionic-wkwebview-engine": "^1.1.4"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",
@@ -82,5 +93,26 @@
     "ios",
     "android"
   ],
-  "description": "Stockpile: An app that manages stuff for organizations"
+  "description": "Stockpile: An app that manages stuff for organizations",
+  "cordova": {
+    "platforms": [
+      "android",
+      "ios"
+    ],
+    "plugins": {
+      "ionic-plugin-keyboard": {},
+      "cordova-plugin-whitelist": {},
+      "cordova-plugin-console": {},
+      "cordova-plugin-statusbar": {},
+      "cordova-plugin-device": {},
+      "cordova-plugin-splashscreen": {},
+      "cordova-custom-config": {},
+      "cordova-plugin-x-toast": {},
+      "phonegap-plugin-barcodescanner": {
+        "CAMERA_USAGE_DESCRIPTION": "The app needs to access your camera to scan barcodes"
+      },
+      "cordova-plugin-inappbrowser": {},
+      "cordova-plugin-wkwebview-engine": {}
+    }
+  }
 }


### PR DESCRIPTION
Xcode 9 now requires a 1024px marketing icon to be included in the built application.

This also revealed that cordova-ios was out of date, so updating it with `ionic cordova platform add ios@4.5.1` remedied that problem. The latest version requires Cordova 7, so run `npm i -g cordova` if yours is out of date.