### PR TITLE
Add search bar in inventory

### DIFF
--- a/src/pages/inventory/inventory.html
+++ b/src/pages/inventory/inventory.html
@@ -10,6 +10,13 @@
       </button>
     </ion-buttons>
   </ion-navbar>
+  <ion-toolbar>
+    <ion-searchbar [(ngModel)]="queryText"
+                   [formControl]="searchControl"
+                   placeholder="Search"
+                   showCancelButton="true">
+    </ion-searchbar>
+  </ion-toolbar>
 </ion-header>
 
 <ion-content>

--- a/src/pages/inventory/inventory.spec.ts
+++ b/src/pages/inventory/inventory.spec.ts
@@ -49,18 +49,29 @@ describe('Inventory Page', () => {
     expect(instance.itemsActions.resetItems).toHaveBeenCalled();
   });
 
+  it('searches items', fakeAsync(() => {
+    instance.ngOnInit();
+    instance.ionViewDidLoad();
+    spyOn(instance, 'loadItems');
+    instance.searchControl.setValue(TestData.queryText);
+    tick(150);
+    expect(instance.loadItems).toHaveBeenCalled();
+  }));
+
   it('fetches items on loadItems()', () => {
     instance.selectedBrandID = TestData.apiItem.brandID;
     instance.selectedModelID = TestData.apiItem.modelID;
     instance.selectedCategoryID = TestData.apiItem.categoryID;
     instance.segment = 0;
+    instance.queryText = TestData.queryText;
     spyOn(instance.itemsActions, 'fetchItems');
     instance.loadItems();
     expect(instance.itemsActions.fetchItems).toHaveBeenCalledWith(
       TestData.apiItem.brandID,
       TestData.apiItem.modelID,
       TestData.apiItem.categoryID,
-      0
+      0,
+      TestData.queryText
     );
   });
 

--- a/src/pages/inventory/inventory.ts
+++ b/src/pages/inventory/inventory.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, ModalController, Platform, AlertController } from 'ionic-angular';
 import { BarcodeScanner } from '@ionic-native/barcode-scanner';
+import { FormControl } from '@angular/forms';
 
 import { ItemData } from '../../providers/item-data';
 import { ItemPropertyData } from '../../providers/item-property-data';
@@ -26,7 +27,9 @@ export class InventoryPage {
   selectedBrandID = -1;
   selectedModelID = -1;
   selectedCategoryID = -1;
+  queryText: string = '';
   items: Observable<Items>;
+  searchControl: FormControl;
 
   constructor(
     public navCtrl: NavController,
@@ -48,6 +51,8 @@ export class InventoryPage {
    * Gets brands, models, categories and items.
    */
   ngOnInit() {
+    this.searchControl = new FormControl();
+
     this.items = this.itemsService.getItems();
 
     this.brandsActions.fetchBrands();
@@ -56,6 +61,15 @@ export class InventoryPage {
 
     // No filters set, so gets all items
     this.itemsActions.fetchItems();
+  }
+
+  /**
+   * Set Observable to search after a short period of time.
+   */
+  ionViewDidLoad() {
+    this.searchControl.valueChanges.debounceTime(100).subscribe(search => {
+      this.loadItems();
+    });
   }
 
   /**
@@ -78,7 +92,8 @@ export class InventoryPage {
       this.selectedBrandID,
       this.selectedModelID,
       this.selectedCategoryID,
-      this.segment
+      this.segment,
+      this.queryText
     );
   }
 

--- a/src/providers/item-data.ts
+++ b/src/providers/item-data.ts
@@ -24,7 +24,13 @@ export class ItemData {
     return this.api.delete(`${Links.item}/${barcode}`);
   }
 
-  filterItems(brandID?: number, modelID?: number, categoryID?: number, available?: number, limit?: number, offset?: number) {
+  filterItems(
+    brandID?: number,
+    modelID?: number,
+    categoryID?: number,
+    available?: number,
+    search?: string
+  ) {
     let params: URLSearchParams = new URLSearchParams();
 
     if (Math.sign(brandID) > 0) {
@@ -43,12 +49,8 @@ export class ItemData {
       params.set('available', available.toString());
     }
 
-    if (limit) {
-      params.set('limit', limit.toString());
-    }
-
-    if (offset) {
-      params.set('offset', offset.toString());
+    if (search) {
+      params.set('search', search);
     }
 
     return this.api.get(Links.item, {

--- a/src/store/items/items.actions.spec.ts
+++ b/src/store/items/items.actions.spec.ts
@@ -23,13 +23,15 @@ describe('Items Actions', () => {
       TestData.apiItem.brandID,
       TestData.apiItem.modelID,
       TestData.apiItem.categoryID,
-      TestData.apiItem.available
+      TestData.apiItem.available,
+      TestData.queryText
     );
     expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ItemsActions.FETCH, {
       brandID: TestData.apiItem.brandID,
       modelID: TestData.apiItem.modelID,
       categoryID: TestData.apiItem.categoryID,
-      available: TestData.apiItem.available
+      available: TestData.apiItem.available,
+      search: TestData.queryText
     }));
   });
 

--- a/src/store/items/items.actions.ts
+++ b/src/store/items/items.actions.ts
@@ -68,8 +68,20 @@ export class ItemsActions {
     private store: Store<AppState>
   ) {}
 
-  fetchItems(brandID?: number, modelID?: number, categoryID?: number, available?: number) {
-    this.store.dispatch(createAction(ItemsActions.FETCH, { brandID, modelID, categoryID, available }));
+  fetchItems(
+    brandID?: number,
+    modelID?: number,
+    categoryID?: number,
+    available?: number,
+    search: string = ''
+  ) {
+    this.store.dispatch(createAction(ItemsActions.FETCH, {
+      brandID,
+      modelID,
+      categoryID,
+      available,
+      search
+    }));
   }
 
   createItem(item: any, itemCustomFields: Array<any>) {

--- a/src/store/items/items.effects.spec.ts
+++ b/src/store/items/items.effects.spec.ts
@@ -48,7 +48,8 @@ describe('Items Effects', () => {
       brandID: TestData.item.brandID,
       modelID: TestData.item.modelID,
       categoryID: TestData.item.categoryID,
-      available: true
+      available: true,
+      search: TestData.queryText
     }));
 
     instance.fetch$.subscribe(
@@ -64,7 +65,8 @@ describe('Items Effects', () => {
       brandID: TestData.item.brandID,
       modelID: TestData.item.modelID,
       categoryID: TestData.item.categoryID,
-      available: true
+      available: true,
+      search: TestData.queryText
     }));
 
     let performedActions = [];

--- a/src/store/items/items.effects.ts
+++ b/src/store/items/items.effects.ts
@@ -35,6 +35,7 @@ export class ItemsEffects {
         action.payload.modelID,
         action.payload.categoryID,
         action.payload.available,
+        action.payload.search
       )
       .map(res => createAction(ItemsActions.FETCH_SUCCESS, res))
       .catch(err => Observable.of(

--- a/src/store/items/items.reducer.ts
+++ b/src/store/items/items.reducer.ts
@@ -19,7 +19,6 @@ export function itemsReducer(items: Items = initialState, action: Action): Items
       return {
         ...items,
         results: Object.assign({},
-          items.results,
           action.payload.results.reduce((obj, item) => {
             obj[item.barcode] = item;
             return obj;


### PR DESCRIPTION
Closes #370

Allows users to search in addition to the other filters (meaning that if they are currently filtering by brand, it will search among the items that have the selected brand and contain the search query i.e. applies the search filter in addition to the other filters when calling the api).

<img width="757" alt="screen shot 2017-10-26 at 9 04 28 pm" src="https://user-images.githubusercontent.com/12487270/32083537-4c5c0554-ba91-11e7-8013-28f2b0e77730.png">
