### PR TITLE
Add ability to refresh token

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export class Actions {
 
 export class Links {
   public static authenticate = '/auth';
+  public static refresh = '/refresh';
   public static item = '/item';
   public static rental = '/rental';
   public static brand = '/brand';

--- a/src/interceptors/errorInterceptor.ts
+++ b/src/interceptors/errorInterceptor.ts
@@ -8,18 +8,24 @@ import {
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { ErrorReport } from '../raven-error-handler';
+import { UserActions } from '../store/user/user.actions';
 
 let errorReport = new ErrorReport();
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
 
+  constructor(public userActions: UserActions) {}
+
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).catch(error => {
       if (error instanceof HttpErrorResponse) {
+        if (error.status === <number>401) {
+          // TODO: Refresh access token and retry request
+        }
         // Don't report 404s and 401s because they are a normal behavior of the api most of
         // the time. Ex: user scans item not present in the database or wrong password
-        if (error.status !== <number>404 || error.status !== <number>401) {
+        else if (error.status !== <number>404) {
           errorReport.reportError(error);
         }
       }

--- a/src/interceptors/errorInterceptor.ts
+++ b/src/interceptors/errorInterceptor.ts
@@ -23,9 +23,9 @@ export class ErrorInterceptor implements HttpInterceptor {
         if (error.status === <number>401) {
           // TODO: Refresh access token and retry request
         }
-        // Don't report 404s and 401s because they are a normal behavior of the api most of
-        // the time. Ex: user scans item not present in the database or wrong password
         else if (error.status !== <number>404) {
+          // Don't report 404s and 401s because they are a normal behavior of the api most of
+          // the time. Ex: user scans item not present in the database or wrong password
           errorReport.reportError(error);
         }
       }

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -153,18 +153,20 @@ export class NavParamsMock {
 }
 
 export class StorageMock {
-  stored = TestData.token;
+  stored = {};
   resolve: boolean = true;
 
   public get(): any {
     return returnPromise(this.resolve, this.stored);
   }
 
-  public set(): any {
+  public set(key: string, value: any): any {
+    this.stored[key] = value;
     return returnPromise(this.resolve);
   }
 
-  public remove(): any {
+  public remove(key: string): any {
+    delete this.stored[key];
     return returnPromise(this.resolve);
   }
 }

--- a/src/providers/user-data.spec.ts
+++ b/src/providers/user-data.spec.ts
@@ -1,120 +1,62 @@
-import { TestBed, inject, fakeAsync } from '@angular/core/testing';
-import { Platform } from 'ionic-angular';
-import { BaseRequestOptions, Http, HttpModule, Response, ResponseOptions } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
-import { Storage } from '@ionic/storage';
-
-import { ApiUrl } from './api-url';
 import { UserData } from './user-data';
 import { TestData } from '../test-data';
 import { Api } from './api';
-import { ApiUrlMock, StorageMock, PlatformMock, ApiMock } from '../mocks';
+import { ApiMock } from '../mocks';
+
+let instance: UserData = null;
 
 describe('UserData Provider', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        { provide: ApiUrl, useClass: ApiUrlMock },
-        UserData,
-        { provide: Api, useClass: ApiMock },
-        { provide: Storage, useClass: StorageMock },
-        { provide: Platform, useClass: PlatformMock },
-        MockBackend,
-        BaseRequestOptions,
-        {
-          provide: Http,
-          useFactory: (backendInstance: MockBackend, defaultOptions: BaseRequestOptions) => {
-            return new Http(backendInstance, defaultOptions);
-          },
-          deps: [MockBackend, BaseRequestOptions]
-        },
-      ],
-      imports: [
-        HttpModule
-      ]
-    });
+    instance = new UserData((<any> new ApiMock));
   });
 
-  it('is created', inject([UserData], (userData: UserData) => {
-    expect(userData).toBeTruthy();
-  }));
+  it('is created', () => {
+    expect(instance).toBeTruthy();
+  });
 
-  it('returns a response on login', inject([UserData, MockBackend], (userData: UserData, mockBackend: MockBackend) => {
-    mockBackend.connections.subscribe(
-      conn => conn.mockRespond(new Response(new ResponseOptions({ body: JSON.stringify(TestData.response) })))
-    );
+  it('returns a response on login', () => {
+    instance.api.value = TestData.loginResponse;
 
-    userData.login(TestData.credentials).subscribe(
-      data => expect(data).toEqual(TestData.response),
+    instance.login(TestData.credentials).subscribe(
+      res => expect(res).toEqual(TestData.loginResponse),
       err => fail(err)
     );
-  }));
+  });
 
-  it('deletes id_token on logout()', inject([UserData], (userData: UserData) => {
-    spyOn(userData.storage, 'remove');
-    userData.logout();
-    expect(userData.storage.remove).toHaveBeenCalledWith('id_token');
-    expect(userData.userID).toEqual('');
-    expect(userData.organizationID).toEqual('');
-  }));
+  it('returns a user on getUser()', () => {
+    instance.api.value = TestData.user;
 
-  it('returns a promise on isLoggedIn', inject([UserData], (userData: UserData) => {
-    userData.isLoggedIn().then(
-      data => expect(data).toBeTruthy(),
-      err => fail(err)
-    );
-  }));
-
-  it('gets token from storage', inject([UserData], (userData: UserData) => {
-    spyOn(userData.storage, 'get').and.callThrough();
-    userData.setUser();
-    expect(userData.storage.get).toHaveBeenCalledWith('id_token');
-  }));
-
-  it('returns a user on getUser()', fakeAsync(inject([UserData], (userData: UserData) => {
-    userData.storage.return = TestData.token;
-    userData.api.value = TestData.user;
-
-    userData.getUser().subscribe(
+    instance.getUser().subscribe(
       res => expect(res).toEqual(TestData.user),
       err => fail(err)
     );
-  })));
+  });
 
-  it('returns a message on changePassword()', fakeAsync(inject([UserData], (userData: UserData) => {
-    userData.storage.return = TestData.token;
+  it('returns a message on changePassword()', () => {
+    instance.api.value = TestData.response;
 
-    userData.changePassword(TestData.passwords.currentPassword, TestData.passwords.newPassword).subscribe(
+    instance.changePassword(TestData.passwords.currentPassword, TestData.passwords.newPassword).subscribe(
       res => expect(res).toEqual(TestData.response),
       err => fail(err)
     );
-  })));
+  });
 
-  it('returns an organization on getOrganization()', fakeAsync(inject([UserData], (userData: UserData) => {
-    userData.api.value = TestData.organization;
+  it('returns an organization on getOrganization()', () => {
+    instance.api.value = TestData.organization;
 
-    userData.getOrganization().subscribe(
+    instance.getOrganization().subscribe(
       res => expect(res).toEqual(TestData.organization),
       err => fail(err)
     );
-  })));
+  });
 
-  it('returns a user on updateUser()', fakeAsync(inject([UserData], (userData: UserData) => {
-    userData.api.value = TestData.user;
+  it('returns a user on updateUser()', () => {
+    instance.api.value = TestData.user;
 
-    userData.updateUser(TestData.user).subscribe(
+    instance.updateUser(TestData.user).subscribe(
       res => expect(res).toEqual(TestData.user),
       err => fail(err)
     );
-  })));
-
-  it('gets something on getInfo()', fakeAsync(inject([UserData], (userData: UserData) => {
-    userData.api.value = TestData.organization;
-
-    userData.getInfo().subscribe(
-      res => expect(res).toEqual(TestData.organization),
-      err => fail(err)
-    );
-  })));
+  });
 });

--- a/src/store/user/user.actions.spec.ts
+++ b/src/store/user/user.actions.spec.ts
@@ -57,4 +57,13 @@ describe('User Actions', () => {
     instance.changeUserPassword(TestData.passwords);
     expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(UserActions.CHANGE_PASSWORD, TestData.passwords));
   });
+
+  it('dispatches action REFRESH_ACCESS_TOKEN', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.refreshAccessToken(TestData.brands.results, TestData.models.results);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(UserActions.REFRESH_ACCESS_TOKEN, {
+      success: TestData.brands.results,
+      fail: TestData.models.results
+    }));
+  });
 });

--- a/src/store/user/user.actions.ts
+++ b/src/store/user/user.actions.ts
@@ -37,6 +37,10 @@ export class UserActions {
   static CHANGE_PASSWORD_SUCCESS = type('[User] Change Password Success');
   static CHANGE_PASSWORD_FAIL = type('[User] Change Password Fail');
 
+  static REFRESH_ACCESS_TOKEN = type('[User] Refresh Access Token');
+  static REFRESH_ACCESS_TOKEN_SUCCESS = type('[User] Refresh Access Token Success');
+  static REFRESH_ACCESS_TOKEN_FAIL = type('[User] Refresh Access Token Fail');
+
   constructor(private store: Store<AppState>) {}
 
   loginUser(credentials: any) {
@@ -65,5 +69,9 @@ export class UserActions {
 
   changeUserPassword(passwords: any) {
     this.store.dispatch(createAction(UserActions.CHANGE_PASSWORD, passwords));
+  }
+
+  refreshAccessToken(success: Array<any> = [], fail: Array<any> = []) {
+    this.store.dispatch(createAction(UserActions.REFRESH_ACCESS_TOKEN, { success, fail }));
   }
 }

--- a/src/store/user/user.effects.spec.ts
+++ b/src/store/user/user.effects.spec.ts
@@ -71,6 +71,9 @@ describe('User Effects', () => {
   });
 
   it('logs out user', () => {
+    instance.storage.set('id_token', TestData.token);
+    instance.storage.set('refresh_token', TestData.token);
+
     runner.queue(createAction(UserActions.LOGOUT));
 
     let performedActions = [];
@@ -82,7 +85,11 @@ describe('User Effects', () => {
     instance.logout$.take(expectedResult.length).subscribe(
       res => performedActions.push(res),
       err => fail(err),
-      () => expect(performedActions).toEqual(expectedResult)
+      () => {
+        expect(performedActions).toEqual(expectedResult);
+        instance.storage.get('id_token').then(token => expect(token).toEqual({}));
+        instance.storage.get('refresh_token').then(token => expect(token).toEqual({}));
+      }
     );
   });
 });


### PR DESCRIPTION
This is just some preliminary work on getting the action and effect set up to refresh access tokens.

The app still needs to dispatch the refresh token event when receiving `401`s from the api (unless the user is on the login page) and retry requests. This has been particularly challenging when dealing with multiple parallel requests, so merging this in will allow me to work on something else until I can figure out how a way to do it.

It shouldn't change any current behavior.