### PR TITLE
Add support to show timestamp for custom fields

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -24,6 +24,10 @@ export class AppMock {
   }
 }
 
+export class HapticMock {
+
+}
+
 export class ConfigMock {
 
   public get(): any {

--- a/src/models/custom-fields.ts
+++ b/src/models/custom-fields.ts
@@ -3,6 +3,7 @@ export interface CustomField {
   readonly name: string;
   readonly organizationID: number;
   readonly sortIndex: number;
+  readonly showTimestamp: boolean;
 }
 
 export interface CustomFields {

--- a/src/models/items.ts
+++ b/src/models/items.ts
@@ -5,6 +5,8 @@ export interface ItemCustomField {
   readonly organizationID: number;
   readonly value: string;
   readonly sortIndex: number;
+  readonly showTimestamp: boolean;
+  readonly updated: string;
 }
 
 export interface Item {

--- a/src/pages/custom-field/custom-field.html
+++ b/src/pages/custom-field/custom-field.html
@@ -19,6 +19,11 @@
       Name is required
     </p>
 
+    <ion-item>
+      <ion-label>Show Last Edited</ion-label>
+      <ion-toggle [ngModel]="(customField | async)?.showTimestamp" type="text" formControlName="showTimestamp"></ion-toggle>
+    </ion-item>
+
     <ion-list>
       <ion-list-header>Categories</ion-list-header>
       <ion-item *ngFor="let category of (customFieldCategories | async)">

--- a/src/pages/custom-field/custom-field.spec.ts
+++ b/src/pages/custom-field/custom-field.spec.ts
@@ -21,8 +21,9 @@ describe('CustomField Page', () => {
     fixture.destroy();
   });
 
-  const updateForm = (name: string) => {
+  const updateForm = (name: string, showTimestamp: boolean) => {
     instance.customFieldForm.controls['name'].setValue(name);
+    instance.customFieldForm.controls['showTimestamp'].setValue(showTimestamp);
   }
 
   it('is created', () => {
@@ -45,8 +46,11 @@ describe('CustomField Page', () => {
 
   it('updates form with values', () => {
     instance.ngOnInit();
-    updateForm(TestData.customField.name);
-    expect(instance.customFieldForm.value).toEqual({ name: TestData.customField.name });
+    updateForm(TestData.customField.name, TestData.customField.showTimestamp);
+    expect(instance.customFieldForm.value).toEqual({
+      name: TestData.customField.name,
+      showTimestamp: TestData.customField.showTimestamp
+    });
   });
 
   it('validates name', () => {

--- a/src/pages/custom-field/custom-field.ts
+++ b/src/pages/custom-field/custom-field.ts
@@ -58,6 +58,7 @@ export class CustomFieldPage {
 
     this.customFieldForm = this.formBuilder.group({
       name: ['', Validators.required],
+      showTimestamp: [false]
     });
 
     if (this.action === Actions.edit) {
@@ -82,7 +83,7 @@ export class CustomFieldPage {
         this.customField.take(1).subscribe(customField => customFieldID = customField.customFieldID);
 
         this.layoutActions.showLoadingMessage(LoadingMessages.updatingCustomField);
-        this.customFieldsActions.updateCustomField({ name: this.customFieldForm.value.name, customFieldID });
+        this.customFieldsActions.updateCustomField({ ...this.customFieldForm.value, customFieldID });
       }
     }
   }

--- a/src/pages/item/item.html
+++ b/src/pages/item/item.html
@@ -41,10 +41,15 @@
       Category is required
     </p>
 
-    <ion-item *ngFor="let customField of (itemCustomFields | async)">
-      <ion-label floating color="primary">{{ customField.customFieldName }}</ion-label>
-      <ion-input [ngModel]="customField?.value" type="text" [name]="customField.customFieldID"></ion-input>
-    </ion-item>
+    <ng-container *ngFor="let customField of (itemCustomFields | async)">
+      <ion-item>
+        <ion-label floating color="primary">{{ customField.customFieldName }}</ion-label>
+        <ion-input [ngModel]="customField?.value" type="text" [name]="customField.customFieldID"></ion-input>
+      </ion-item>
+      <p ion-text *ngIf="customField.showTimestamp && customField.value" color="primary" padding-left>
+        Last updated: {{ customField.updated | date }}
+      </p>
+    </ng-container>
 
     <ion-spinner class="center-spinner" *ngIf="showLoadingSpinner | async"></ion-spinner>
 

--- a/src/pages/item/item.spec.ts
+++ b/src/pages/item/item.spec.ts
@@ -59,6 +59,7 @@ describe('Item Page', () => {
   it('creates item onSave() if action is add', () => {
     instance.action = Actions.add;
     instance.tempItem = Observable.of(TestData.apiItem);
+    instance.itemCustomFields = Observable.of(TestData.itemCustomFields.results);
     spyOn(instance.layoutActions, 'showLoadingMessage');
     spyOn(instance.itemsActions, 'createItem');
     instance.onSave(TestData.itemCustomFieldsForm);
@@ -69,6 +70,7 @@ describe('Item Page', () => {
   it('updates item onSave() if action is edit', () => {
     instance.action = Actions.edit;
     instance.tempItem = Observable.of(TestData.apiItem);
+    instance.itemCustomFields = Observable.of(TestData.itemCustomFields.results);
     spyOn(instance.layoutActions, 'showLoadingMessage');
     spyOn(instance.itemsActions, 'updateItem');
     instance.onSave(TestData.itemCustomFieldsForm);

--- a/src/pages/item/item.ts
+++ b/src/pages/item/item.ts
@@ -93,12 +93,23 @@ export class ItemPage {
         barcode: i.barcode
       });
 
-      // Transform the values from the form to an array
       let itemCustomFieldsList = [];
+      const shouldUpdate = (key, value) => {
+        let field;
+        // Using == below to compare instead of === because the key from the
+        // form comes back as a string instead of a number
+        this.itemCustomFields.subscribe(
+          fields => field = fields.find(itemField => itemField.customFieldID == key)
+        );
+        return field.value !== value;
+      };
+
+      // Transform the values from the form to an array
       Object.keys(form.value).map(key => {
         itemCustomFieldsList.push({
           customFieldID: key,
-          value: form.value[key]
+          value: form.value[key],
+          shouldUpdate: shouldUpdate(key, form.value[key])
         });
       });
 

--- a/src/store/items/items.effects.spec.ts
+++ b/src/store/items/items.effects.spec.ts
@@ -428,6 +428,7 @@ describe('Items Effects', () => {
   });
 
   it('does not push page to add item if item exists', () => {
+    instance.itemData.resolve = true;
     runner.queue(createAction(ItemsActions.START_CREATE, TestData.barcode));
 
     let performedActions = [];

--- a/src/store/items/items.effects.ts
+++ b/src/store/items/items.effects.ts
@@ -94,11 +94,13 @@ export class ItemsEffects {
         let requests = [];
 
         action.payload.itemCustomFields.map(itemCustomField => {
-          requests.push(this.itemData.updateItemCustomField(
-            action.payload.item.barcode,
-            itemCustomField.customFieldID,
-            { value: itemCustomField.value }
-          ).toPromise());
+          if (itemCustomField.shouldUpdate) {
+            requests.push(this.itemData.updateItemCustomField(
+              action.payload.item.barcode,
+              itemCustomField.customFieldID,
+              { value: itemCustomField.value }
+            ).toPromise());
+          }
         });
 
         return Observable.from(Promise.all(requests))

--- a/src/store/items/items.effects.ts
+++ b/src/store/items/items.effects.ts
@@ -307,7 +307,7 @@ export class ItemsEffects {
       .map(() => createAction(AppActions.SHOW_MESSAGE, constants.Messages.itemAlreadyExists))
       .catch(err => {
         // Push the page if we receive a 404 (barcode doesn't exist)
-        if (err.code === 'NotFoundError') {
+        if (err.code === 'NotFound') {
           return Observable.of(
             createAction(AppActions.PUSH_PAGE, {
               page: ItemPage,

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -648,17 +648,20 @@ export class TestData {
         {
           name: 'Cost',
           customFieldID: 1,
-          organizationID: 1
+          organizationID: 1,
+          showTimestamp: true
         },
         {
           name: 'Serial number',
           customFieldID: 2,
-          organizationID: 1
+          organizationID: 1,
+          showTimestamp: true
         },
         {
           name: 'Notes',
           customFieldID: 3,
-          organizationID: 1
+          organizationID: 1,
+          showTimestamp: false
         }
       ],
       showLoadingSpinner: false
@@ -700,7 +703,8 @@ export class TestData {
   public static customField = {
     name: 'Cost',
     customFieldID: 1,
-    organizationID: 1
+    organizationID: 1,
+    showTimestamp: true
   };
 
   public static customFields = {
@@ -708,17 +712,20 @@ export class TestData {
       {
         name: 'Cost',
         customFieldID: 1,
-        organizationID: 1
+        organizationID: 1,
+        showTimestamp: true
       },
       {
         name: 'Serial number',
         customFieldID: 2,
-        organizationID: 1
+        organizationID: 1,
+        showTimestamp: true
       },
       {
         name: 'Notes',
         customFieldID: 3,
-        organizationID: 1
+        organizationID: 1,
+        showTimestamp: false
       }
     ]
   };

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -244,7 +244,7 @@ export class TestData {
   };
 
   public static error = {
-    code: 'NotFoundError',
+    code: 'NotFound',
     message: 'Error message'
   };
 
@@ -825,14 +825,17 @@ export class TestData {
     {
       customFieldID: '1',
       value: '350',
+      shouldUpdate: false
     },
     {
       customFieldID: '2',
       value: '1234567890',
+      shouldUpdate: false
     },
     {
       customFieldID: '3',
       value: 'This is a note',
+      shouldUpdate: false
     }
   ];
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -28,7 +28,8 @@ import {
   AlertController,
   Events,
   LoadingController,
-  DeepLinker
+  DeepLinker,
+  Haptic
 } from 'ionic-angular';
 import { NgForm } from '@angular/forms';
 import {
@@ -71,7 +72,8 @@ import {
   OrganizationServiceMock,
   UserServiceMock,
   InAppBrowserMock,
-  DeepLinkerMock
+  DeepLinkerMock,
+  HapticMock
 } from './mocks';
 import { BrandsActions } from './store/brands/brands.actions';
 import { CustomFieldCategoriesActions } from './store/custom-field-categories/custom-field-categories.actions';
@@ -199,6 +201,7 @@ export class TestUtils {
         { provide: UserService, useClass: UserServiceMock },
         { provide: InAppBrowser, useClass: InAppBrowserMock },
         { provide: DeepLinker, useClass: DeepLinkerMock }
+        { provide: Haptic, useClass: HapticMock }
       ],
       imports: [
         FormsModule,


### PR DESCRIPTION
Closes #364 

I defaulted showing the timestamp to false when creating new custom fields. I feel like this should also be the case on the back end. Users will probably only want to show the timestamp for fields that change regularly, so there will probably be less of those. Making it false by default also makes sure it doesn't clutter the UI with unnecessary info if users forget to turn it off.

@AdamVig do you agree?