### PR TITLE
Reload lists on creation of update

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -560,6 +560,7 @@ export class ItemsActionsMock {
   public fetchItemCustomFields() {}
   public fetchItemCustomFieldsByCategory() {}
   public startCreate() {}
+  public updateFilters() {}
 }
 
 export class KitModelsActionsMock {
@@ -664,7 +665,7 @@ export class CustomFieldsServiceMock {
 
 export class ItemsServiceMock {
   public getItems() {
-    return Observable.of(TestData.items);
+    return Observable.of(TestData.state.items);
   }
 
   public getShouldLoadMoreItems() {

--- a/src/models/items.ts
+++ b/src/models/items.ts
@@ -29,4 +29,5 @@ export interface Items {
   readonly tempItemCustomFields: Array<ItemCustomField>;
   readonly rentals: { [barcode: string]: Item };
   readonly showLoadingSpinner: boolean;
+  readonly filters: any;
 }

--- a/src/pages/inventory-filter/inventory-filter.spec.ts
+++ b/src/pages/inventory-filter/inventory-filter.spec.ts
@@ -5,9 +5,11 @@ import {
   BrandsActionsMock,
   CategoriesActionsMock,
   ModelsActionsMock,
+  ItemsActionsMock
   BrandsServiceMock,
   CategoriesServiceMock,
   ModelsServiceMock,
+  ItemsServiceMock,
 } from '../../mocks';
 
 import { InventoryFilterPage } from './inventory-filter';
@@ -26,6 +28,8 @@ describe('InventoryFilter Page', () => {
       <any> new ModelsActionsMock,
       <any> new CategoriesServiceMock,
       <any> new CategoriesActionsMock,
+      <any> new ItemsServiceMock,
+      <any> new ItemsActionsMock
     );
   });
 
@@ -33,22 +37,11 @@ describe('InventoryFilter Page', () => {
     expect(instance).toBeTruthy();
   });
 
-  it('gets navParam selectedBrandID', () => {
-    instance.navParams.param = TestData.apiItem.brandID;
+  it('gets ids from store', () => {
     instance.ngOnInit();
-    expect(instance.selectedBrandID).toEqual(TestData.apiItem.brandID);
-  });
-
-  it('gets navParam selectedModelID', () => {
-    instance.navParams.param = TestData.apiItem.modelID;
-    instance.ngOnInit();
-    expect(instance.selectedModelID).toEqual(TestData.apiItem.modelID);
-  });
-
-  it('gets navParam selectedCategoryID', () => {
-    instance.navParams.param = TestData.apiItem.categoryID;
-    instance.ngOnInit();
-    expect(instance.selectedCategoryID).toEqual(TestData.apiItem.categoryID);
+    expect(instance.selectedBrandID).toEqual(TestData.itemFilters.brandID);
+    expect(instance.selectedModelID).toEqual(TestData.itemFilters.modelID);
+    expect(instance.selectedCategoryID).toEqual(TestData.itemFilters.categoryID);
   });
 
   it('calls filterModels if selectedBrandID is not -1', () => {
@@ -56,13 +49,6 @@ describe('InventoryFilter Page', () => {
     spyOn(instance, 'onFilterModels');
     instance.ngOnInit();
     expect(instance.onFilterModels).toHaveBeenCalled();
-  });
-
-  it('does not call onFilterModels if selectedBrandID is -1', () => {
-    instance.navParams.param = -1;
-    spyOn(instance, 'onFilterModels');
-    instance.ngOnInit();
-    expect(instance.onFilterModels).not.toHaveBeenCalled();
   });
 
   it('filters models on filterModels()', () => {
@@ -87,18 +73,20 @@ describe('InventoryFilter Page', () => {
   });
 
   it('dismisses modal on applyFilters', () => {
-    instance.selectedBrandID = TestData.apiItem.brandID;
-    instance.selectedModelID = TestData.apiItem.modelID;
-    instance.selectedCategoryID = TestData.apiItem.categoryID;
+    instance.selectedBrandID = TestData.itemFilters.brandID;
+    instance.selectedModelID = TestData.itemFilters.modelID;
+    instance.selectedCategoryID = TestData.itemFilters.categoryID;
 
     const ids = {
-      selectedBrandID: TestData.apiItem.brandID,
-      selectedModelID: TestData.apiItem.modelID,
-      selectedCategoryID: TestData.apiItem.categoryID
+      brandID: TestData.itemFilters.brandID,
+      modelID: TestData.itemFilters.modelID,
+      categoryID: TestData.itemFilters.categoryID
     };
 
     spyOn(instance.viewCtrl, 'dismiss');
+    spyOn(instance.itemsActions, 'updateFilters');
     instance.onApplyFilters();
-    expect(instance.viewCtrl.dismiss).toHaveBeenCalledWith(ids);
+    expect(instance.viewCtrl.dismiss).toHaveBeenCalled();
+    expect(instance.itemsActions.updateFilters).toHaveBeenCalledWith(ids);
   });
 });

--- a/src/pages/inventory-filter/inventory-filter.ts
+++ b/src/pages/inventory-filter/inventory-filter.ts
@@ -3,9 +3,11 @@ import { NavParams, ViewController } from 'ionic-angular';
 import { BrandsService } from '../../services/brands.service';
 import { ModelsService } from '../../services/models.service';
 import { CategoriesService } from '../../services/categories.service';
+import { ItemsService } from '../../services/items.service';
 import { BrandsActions } from '../../store/brands/brands.actions';
 import { ModelsActions } from '../../store/models/models.actions';
 import { CategoriesActions } from '../../store/categories/categories.actions';
+import { ItemsActions } from '../../store/items/items.actions';
 import { Brands, Categories, Models } from '../../models';
 import { Observable } from 'rxjs/Observable';
 
@@ -29,7 +31,9 @@ export class InventoryFilterPage {
     public modelsService: ModelsService,
     public modelsActions: ModelsActions,
     public categoriesService: CategoriesService,
-    public categoriesActions: CategoriesActions
+    public categoriesActions: CategoriesActions,
+    public itemsService: ItemsService,
+    public itemsActions: ItemsActions
   ) {}
 
   /**
@@ -40,9 +44,13 @@ export class InventoryFilterPage {
     this.brands = this.brandsService.getBrands();
     this.models = this.modelsService.getModels();
     this.categories = this.categoriesService.getCategories();
-    this.selectedBrandID = this.navParams.get('selectedBrandID');
-    this.selectedModelID = this.navParams.get('selectedModelID');
-    this.selectedCategoryID = this.navParams.get('selectedCategoryID');
+    let filters;
+    this.itemsService.getItems().take(1).subscribe(items => {
+      filters = items.filters;
+    });
+    this.selectedBrandID = filters.brandID;
+    this.selectedModelID = filters.modelID;
+    this.selectedCategoryID = filters.categoryID;
 
     if (this.selectedModelID !== -1) {
       this.onFilterModels();
@@ -74,15 +82,14 @@ export class InventoryFilterPage {
   }
 
   /**
-   * Closes the modal and passes the selected filters.
+   * Closes the modal and saves the selected filters.
    */
   onApplyFilters() {
-    const ids = {
-      selectedBrandID: this.selectedBrandID,
-      selectedModelID: this.selectedModelID,
-      selectedCategoryID: this.selectedCategoryID
-    };
-
-    this.viewCtrl.dismiss(ids);
+    this.itemsActions.updateFilters({
+      brandID: this.selectedBrandID,
+      modelID: this.selectedModelID,
+      categoryID: this.selectedCategoryID
+    });
+    this.viewCtrl.dismiss();
   }
 }

--- a/src/pages/inventory/inventory.spec.ts
+++ b/src/pages/inventory/inventory.spec.ts
@@ -7,6 +7,7 @@ import { Actions } from '../../constants';
 import { ItemPage } from '../item/item';
 import { InventoryFilterPage } from '../inventory-filter/inventory-filter';
 import { PlatformMockIsCore, PlatformMockIsCordova } from '../../mocks';
+import { Observable } from 'rxjs/Observable';
 
 let fixture: ComponentFixture<InventoryPage> = null;
 let instance: any = null;
@@ -42,6 +43,7 @@ describe('Inventory Page', () => {
   });
 
   it('loads items on filterItems()', () => {
+    instance.items = Observable.of({ filters: TestData.itemFilters });
     spyOn(instance, 'loadItems');
     spyOn(instance.itemsActions, 'resetItems');
     instance.onFilterItems();
@@ -59,20 +61,9 @@ describe('Inventory Page', () => {
   }));
 
   it('fetches items on loadItems()', () => {
-    instance.selectedBrandID = TestData.apiItem.brandID;
-    instance.selectedModelID = TestData.apiItem.modelID;
-    instance.selectedCategoryID = TestData.apiItem.categoryID;
-    instance.segment = 0;
-    instance.queryText = TestData.queryText;
     spyOn(instance.itemsActions, 'fetchItems');
     instance.loadItems();
-    expect(instance.itemsActions.fetchItems).toHaveBeenCalledWith(
-      TestData.apiItem.brandID,
-      TestData.apiItem.modelID,
-      TestData.apiItem.categoryID,
-      0,
-      TestData.queryText
-    );
+    expect(instance.itemsActions.fetchItems).toHaveBeenCalled();
   });
 
   it('pushes ItemPage on nav on viewItem()', () => {
@@ -124,15 +115,8 @@ describe('Inventory Page', () => {
   }));
 
   it('creates a modal onOpenFilters()', () => {
-    instance.selectedBrandID = TestData.apiItem.brandID;
-    instance.selectedModelID = TestData.apiItem.modelID;
-    instance.selectedCategoryID = TestData.apiItem.categoryID;
     spyOn(instance.modalCtrl, 'create').and.callThrough();
     instance.onOpenFilters();
-    expect(instance.modalCtrl.create).toHaveBeenCalledWith(InventoryFilterPage, {
-      selectedBrandID: TestData.apiItem.brandID,
-      selectedModelID: TestData.apiItem.modelID,
-      selectedCategoryID: TestData.apiItem.categoryID
-    });
+    expect(instance.modalCtrl.create).toHaveBeenCalledWith(InventoryFilterPage);
   });
 });

--- a/src/store/brands/brands.effects.spec.ts
+++ b/src/store/brands/brands.effects.spec.ts
@@ -76,6 +76,7 @@ describe('Brands Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(BrandsActions.CREATE_SUCCESS, TestData.response),
+      createAction(BrandsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.brandAdded),
     ];
@@ -96,6 +97,7 @@ describe('Brands Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(BrandsActions.CREATE_SUCCESS, TestData.response),
+      createAction(BrandsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.brandAdded),
       createAction(AppActions.POP_NAV)
@@ -135,6 +137,7 @@ describe('Brands Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(BrandsActions.UPDATE_SUCCESS, TestData.response),
+      createAction(BrandsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.brandEdited),
       createAction(AppActions.POP_NAV)
@@ -171,6 +174,7 @@ describe('Brands Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(BrandsActions.DELETE_SUCCESS, TestData.response),
+      createAction(BrandsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.brandDeleted),
       createAction(AppActions.POP_NAV)

--- a/src/store/brands/brands.effects.ts
+++ b/src/store/brands/brands.effects.ts
@@ -41,6 +41,7 @@ export class BrandsEffects {
       .concatMap(res => {
         let success = [
           createAction(BrandsActions.CREATE_SUCCESS, res),
+          createAction(BrandsActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.brandAdded),
         ];
@@ -67,6 +68,7 @@ export class BrandsEffects {
     .mergeMap(action => this.itemPropertyData.updateBrand(action.payload, action.payload.brandID)
       .concatMap(res => [
         createAction(BrandsActions.UPDATE_SUCCESS, res),
+        createAction(BrandsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.brandEdited),
         createAction(AppActions.POP_NAV)
@@ -87,6 +89,7 @@ export class BrandsEffects {
     .mergeMap(action => this.itemPropertyData.deleteBrand(action.payload)
       .concatMap(res => [
         createAction(BrandsActions.DELETE_SUCCESS, res),
+        createAction(BrandsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.brandDeleted),
         createAction(AppActions.POP_NAV)

--- a/src/store/brands/brands.reducer.ts
+++ b/src/store/brands/brands.reducer.ts
@@ -18,7 +18,6 @@ export function brandsReducer(brands: Brands = initialState, action: Action): Br
       return {
         ...brands,
         results: Object.assign({},
-          brands.results,
           action.payload.results.reduce((obj, brand) => {
             obj[brand.brandID] = brand;
             return obj;
@@ -30,22 +29,6 @@ export function brandsReducer(brands: Brands = initialState, action: Action): Br
       };
     case BrandsActions.FETCH_FAIL:
       return { ...brands, showLoadingSpinner: false };
-    case BrandsActions.CREATE_SUCCESS:
-    case BrandsActions.UPDATE_SUCCESS:
-      return {
-        ...brands,
-        results: {
-          ...brands.results,
-          [action.payload.brandID]: action.payload
-        }
-      };
-    case BrandsActions.DELETE_SUCCESS:
-      const results = Object.assign({}, brands.results);
-      delete results[action.payload.id];
-      return {
-        ...brands,
-        results
-      };
     case BrandsActions.FILTER:
       const filtered = Object.keys(brands.results)
         .map((key) => brands.results[key])

--- a/src/store/categories/categories.effects.spec.ts
+++ b/src/store/categories/categories.effects.spec.ts
@@ -76,6 +76,7 @@ describe('Categories Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CategoriesActions.CREATE_SUCCESS, TestData.response),
+      createAction(CategoriesActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.categoryAdded),
     ];
@@ -96,6 +97,7 @@ describe('Categories Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CategoriesActions.CREATE_SUCCESS, TestData.response),
+      createAction(CategoriesActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.categoryAdded),
       createAction(AppActions.POP_NAV)
@@ -135,6 +137,7 @@ describe('Categories Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CategoriesActions.UPDATE_SUCCESS, TestData.response),
+      createAction(CategoriesActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.categoryEdited),
       createAction(AppActions.POP_NAV)
@@ -171,6 +174,7 @@ describe('Categories Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CategoriesActions.DELETE_SUCCESS, TestData.response),
+      createAction(CategoriesActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.categoryDeleted),
       createAction(AppActions.POP_NAV)

--- a/src/store/categories/categories.effects.ts
+++ b/src/store/categories/categories.effects.ts
@@ -41,6 +41,7 @@ export class CategoriesEffects {
       .concatMap(res => {
         let success = [
           createAction(CategoriesActions.CREATE_SUCCESS, res),
+          createAction(CategoriesActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.categoryAdded),
         ];
@@ -67,6 +68,7 @@ export class CategoriesEffects {
       .mergeMap(action => this.itemPropertyData.updateCategory(action.payload, action.payload.categoryID)
         .concatMap(res => [
           createAction(CategoriesActions.UPDATE_SUCCESS, res),
+          createAction(CategoriesActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.categoryEdited),
           createAction(AppActions.POP_NAV)
@@ -87,6 +89,7 @@ export class CategoriesEffects {
       .mergeMap(action => this.itemPropertyData.deleteCategory(action.payload)
         .concatMap(res => [
           createAction(CategoriesActions.DELETE_SUCCESS, res),
+          createAction(CategoriesActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.categoryDeleted),
           createAction(AppActions.POP_NAV)

--- a/src/store/categories/categories.reducer.ts
+++ b/src/store/categories/categories.reducer.ts
@@ -18,7 +18,6 @@ export function categoriesReducer(categories: Categories = initialState, action:
       return {
         ...categories,
         results: Object.assign({},
-          categories.results,
           action.payload.results.reduce((obj, category) => {
             obj[category.categoryID] = category;
             return obj;
@@ -30,22 +29,6 @@ export function categoriesReducer(categories: Categories = initialState, action:
       };
     case CategoriesActions.FETCH_FAIL:
       return { ...categories, showLoadingSpinner: false };
-    case CategoriesActions.CREATE_SUCCESS:
-    case CategoriesActions.UPDATE_SUCCESS:
-      return {
-        ...categories,
-        results: {
-          ...categories.results,
-          [action.payload.categoryID]: action.payload
-        }
-      };
-    case CategoriesActions.DELETE_SUCCESS:
-      const results = Object.assign({}, categories.results);
-      delete results[action.payload.id];
-      return {
-        ...categories,
-        results
-      };
     case CategoriesActions.FILTER:
       return Object.assign({}, categories, {
         filtered: Object.keys(categories.results)

--- a/src/store/custom-fields/custom-fields.effects.spec.ts
+++ b/src/store/custom-fields/custom-fields.effects.spec.ts
@@ -74,6 +74,7 @@ describe('Custom Fields Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CustomFieldsActions.DELETE_SUCCESS, TestData.response),
+      createAction(CustomFieldsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.customFieldDeleted),
       createAction(AppActions.POP_NAV)
@@ -110,6 +111,7 @@ describe('Custom Fields Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CustomFieldsActions.CREATE_SUCCESS, TestData.customField),
+      createAction(CustomFieldsActions.FETCH),
       createAction(CustomFieldCategoriesActions.UPDATE, {
         customFieldID: TestData.customField.customFieldID,
         message: Messages.customFieldAdded
@@ -151,6 +153,7 @@ describe('Custom Fields Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(CustomFieldsActions.UPDATE_SUCCESS, TestData.customField),
+      createAction(CustomFieldsActions.FETCH),
       createAction(CustomFieldCategoriesActions.UPDATE, {
         customFieldID: TestData.customField.customFieldID,
         message: Messages.customFieldEdited

--- a/src/store/custom-fields/custom-fields.effects.ts
+++ b/src/store/custom-fields/custom-fields.effects.ts
@@ -41,6 +41,7 @@ export class CustomFieldsEffects {
     .mergeMap(action => this.customFieldData.deleteCustomField(action.payload)
       .concatMap(res => [
         createAction(CustomFieldsActions.DELETE_SUCCESS, res),
+        createAction(CustomFieldsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.customFieldDeleted),
         createAction(AppActions.POP_NAV)
@@ -61,6 +62,7 @@ export class CustomFieldsEffects {
     .mergeMap(action => this.customFieldData.createCustomField(action.payload)
       .concatMap(res => [
         createAction(CustomFieldsActions.CREATE_SUCCESS, res),
+        createAction(CustomFieldsActions.FETCH),
         createAction(CustomFieldCategoriesActions.UPDATE, {
           customFieldID: res.customFieldID,
           message: Messages.customFieldAdded
@@ -82,6 +84,7 @@ export class CustomFieldsEffects {
     .mergeMap(action => this.customFieldData.updateCustomField(action.payload)
       .concatMap(res => [
         createAction(CustomFieldsActions.UPDATE_SUCCESS, res),
+        createAction(CustomFieldsActions.FETCH),
         createAction(CustomFieldCategoriesActions.UPDATE, {
           customFieldID: res.customFieldID,
           message: Messages.customFieldEdited

--- a/src/store/custom-fields/custom-fields.reducer.ts
+++ b/src/store/custom-fields/custom-fields.reducer.ts
@@ -16,7 +16,6 @@ export function customFieldsReducer(customFields: CustomFields = initialState, a
       return {
         ...customFields,
         results: Object.assign({},
-          customFields.results,
           action.payload.results.reduce((obj, customField) => {
             obj[customField.customFieldID] = customField;
             return obj;
@@ -26,19 +25,6 @@ export function customFieldsReducer(customFields: CustomFields = initialState, a
       };
     case CustomFieldsActions.FETCH_FAIL:
       return { ...customFields, showLoadingSpinner: false };
-    case CustomFieldsActions.DELETE_SUCCESS:
-      const results = Object.assign({}, customFields.results);
-      delete results[action.payload.id];
-      return { ...customFields, results };
-    case CustomFieldsActions.CREATE_SUCCESS:
-    case CustomFieldsActions.UPDATE_SUCCESS:
-      return {
-        ...customFields,
-        results: {
-          ...customFields.results,
-          [action.payload.customFieldID]: action.payload
-        }
-      };
     default:
       return customFields;
   }

--- a/src/store/external-renters/external-renters.effects.spec.ts
+++ b/src/store/external-renters/external-renters.effects.spec.ts
@@ -76,6 +76,7 @@ describe('ExternalRenters Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ExternalRentersActions.CREATE_SUCCESS, TestData.response),
+      createAction(ExternalRentersActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
     ];
@@ -96,6 +97,7 @@ describe('ExternalRenters Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ExternalRentersActions.CREATE_SUCCESS, TestData.response),
+      createAction(ExternalRentersActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
       createAction(AppActions.POP_NAV)
@@ -135,6 +137,7 @@ describe('ExternalRenters Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ExternalRentersActions.UPDATE_SUCCESS, TestData.response),
+      createAction(ExternalRentersActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterEdited),
       createAction(AppActions.POP_NAV)
@@ -171,6 +174,7 @@ describe('ExternalRenters Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ExternalRentersActions.DELETE_SUCCESS, TestData.response),
+      createAction(ExternalRentersActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterDeleted),
       createAction(AppActions.POP_NAV)

--- a/src/store/external-renters/external-renters.effects.ts
+++ b/src/store/external-renters/external-renters.effects.ts
@@ -41,6 +41,7 @@ export class ExternalRentersEffects {
       .concatMap(res => {
         let success = [
           createAction(ExternalRentersActions.CREATE_SUCCESS, res),
+          createAction(ExternalRentersActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterAdded),
         ];
@@ -67,6 +68,7 @@ export class ExternalRentersEffects {
     .mergeMap(action => this.externalRenterData.updateExternalRenter(action.payload, action.payload.externalRenterID)
       .concatMap(res => [
         createAction(ExternalRentersActions.UPDATE_SUCCESS, res),
+        createAction(ExternalRentersActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterEdited),
         createAction(AppActions.POP_NAV)
@@ -87,6 +89,7 @@ export class ExternalRentersEffects {
     .mergeMap(action => this.externalRenterData.deleteExternalRenter(action.payload)
       .concatMap(res => [
         createAction(ExternalRentersActions.DELETE_SUCCESS, res),
+        createAction(ExternalRentersActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.externalRenterDeleted),
         createAction(AppActions.POP_NAV)

--- a/src/store/external-renters/external-renters.reducer.ts
+++ b/src/store/external-renters/external-renters.reducer.ts
@@ -18,7 +18,6 @@ export function externalRentersReducer(externalRenters: ExternalRenters = initia
       return {
         ...externalRenters,
         results: Object.assign({},
-          externalRenters.results,
           action.payload.results.reduce((obj, externalRenter) => {
             obj[externalRenter.externalRenterID] = externalRenter;
             return obj;
@@ -27,22 +26,6 @@ export function externalRentersReducer(externalRenters: ExternalRenters = initia
         filtered: action.payload.results,
         showAddNew: false,
         showLoadingSpinner: false
-      };
-    case ExternalRentersActions.CREATE_SUCCESS:
-    case ExternalRentersActions.UPDATE_SUCCESS:
-      return {
-        ...externalRenters,
-        results: {
-          ...externalRenters.results,
-          [action.payload.externalRenterID]: action.payload
-        }
-      };
-    case ExternalRentersActions.DELETE_SUCCESS:
-      const results = Object.assign({}, externalRenters.results);
-      delete results[action.payload.id];
-      return {
-        ...externalRenters,
-        results
       };
     case ExternalRentersActions.FILTER:
       const filtered = Object.keys(externalRenters.results)

--- a/src/store/items/items.actions.spec.ts
+++ b/src/store/items/items.actions.spec.ts
@@ -133,4 +133,10 @@ describe('Items Actions', () => {
     instance.startCreate(TestData.barcode);
     expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ItemsActions.START_CREATE, TestData.barcode));
   });
+
+  it('dispatches action UPDATE_FILTERS', () => {
+    spyOn(instance.store, 'dispatch');
+    instance.updateFilters(TestData.ItemFilters);
+    expect(instance.store.dispatch).toHaveBeenCalledWith(createAction(ItemsActions.UPDATE_FILTERS, TestData.ItemFilters));
+  });
 });

--- a/src/store/items/items.actions.ts
+++ b/src/store/items/items.actions.ts
@@ -62,6 +62,8 @@ export class ItemsActions {
   static UPDATE_ITEM_CUSTOM_FIELDS_SUCCESS = type('[Items] Update Item Custom Fields Success');
   static UPDATE_ITEM_CUSTOM_FIELDS_FAIL = type('[Items] Update Item Custom Fields Fail');
 
+  static UPDATE_FILTERS = type('[Items] Update Item Filters');
+
   static START_CREATE = type('[Items] Start Create');
 
   constructor(
@@ -146,5 +148,9 @@ export class ItemsActions {
 
   startCreate(barcode: string) {
     this.store.dispatch(createAction(ItemsActions.START_CREATE, barcode));
+  }
+
+  updateFilters(filters: any) {
+    this.store.dispatch(createAction(ItemsActions.UPDATE_FILTERS, filters));
   }
 }

--- a/src/store/items/items.effects.spec.ts
+++ b/src/store/items/items.effects.spec.ts
@@ -43,44 +43,6 @@ describe('Items Effects', () => {
     expect(instance).toBeTruthy();
   });
 
-  it('fetches items', () => {
-    runner.queue(createAction(ItemsActions.FETCH, {
-      brandID: TestData.item.brandID,
-      modelID: TestData.item.modelID,
-      categoryID: TestData.item.categoryID,
-      available: true,
-      search: TestData.queryText
-    }));
-
-    instance.fetch$.subscribe(
-      res => expect(res).toEqual(createAction(ItemsActions.FETCH_SUCCESS, TestData.items)),
-      err => fail(err)
-    );
-  });
-
-  it('returns error if fetch fails', () => {
-    instance.itemData.resolve = false;
-
-    runner.queue(createAction(ItemsActions.FETCH, {
-      brandID: TestData.item.brandID,
-      modelID: TestData.item.modelID,
-      categoryID: TestData.item.categoryID,
-      available: true,
-      search: TestData.queryText
-    }));
-
-    let performedActions = [];
-    const expectedResult = [
-      createAction(ItemsActions.FETCH_FAIL, TestData.error),
-      createAction(AppActions.SHOW_MESSAGE, TestData.error.message)
-    ];
-    instance.fetch$.take(expectedResult.length).subscribe(
-      res => performedActions.push(res),
-      err => fail(err),
-      () => expect(performedActions).toEqual(expectedResult)
-    );
-  });
-
   it('creates an item', () => {
     runner.queue(createAction(ItemsActions.CREATE, {
       item: TestData.apiItem,
@@ -175,6 +137,7 @@ describe('Items Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ItemsActions.DELETE_SUCCESS, TestData.response),
+      createAction(ItemsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.itemDeleted),
       createAction(AppActions.POP_NAV)

--- a/src/store/items/items.effects.ts
+++ b/src/store/items/items.effects.ts
@@ -30,12 +30,13 @@ export class ItemsEffects {
   @Effect()
   fetch$ = this.actions$
     .ofType(ItemsActions.FETCH)
-    .mergeMap(action => this.itemData.filterItems(
-        action.payload.brandID,
-        action.payload.modelID,
-        action.payload.categoryID,
-        action.payload.available,
-        action.payload.search
+    .withLatestFrom(this.store$)
+    .mergeMap(([action, store]) => this.itemData.filterItems(
+        store.items.filters.brandID,
+        store.items.filters.modelID,
+        store.items.filters.categoryID,
+        store.items.filters.available,
+        store.items.filters.search
       )
       .map(res => createAction(ItemsActions.FETCH_SUCCESS, res))
       .catch(err => Observable.of(
@@ -106,6 +107,7 @@ export class ItemsEffects {
         return Observable.from(Promise.all(requests))
           .concatMap(res => [
             createAction(action.payload.success, action.payload.item),
+            createAction(ItemsActions.FETCH),
             createAction(LayoutActions.HIDE_LOADING_MESSAGE),
             createAction(AppActions.SHOW_MESSAGE, Messages.itemEdited),
             createAction(AppActions.POP_NAV)
@@ -126,6 +128,7 @@ export class ItemsEffects {
     .mergeMap(action => this.itemData.deleteItem(action.payload)
       .concatMap(res => [
         createAction(ItemsActions.DELETE_SUCCESS, res),
+        createAction(ItemsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.itemDeleted),
         createAction(AppActions.POP_NAV)
@@ -226,6 +229,7 @@ export class ItemsEffects {
       return Observable.from(Promise.all(returns))
         .concatMap(() => [
           createAction(ItemsActions.RETURN_SUCCESS),
+          createAction(ItemsActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.itemsReturned),
           createAction(AppActions.POP_NAV)
@@ -252,6 +256,7 @@ export class ItemsEffects {
       return this.itemData.rent({ ...action.payload, items })
         .concatMap(() => [
           createAction(ItemsActions.RENT_SUCCESS),
+          createAction(ItemsActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.itemsRented),
           createAction(AppActions.POP_NAV_TO_ROOT)

--- a/src/store/items/items.reducer.ts
+++ b/src/store/items/items.reducer.ts
@@ -8,7 +8,8 @@ const initialState = {
   tempItem: {},
   tempItemCustomFields: [],
   rentals: {},
-  showLoadingSpinner: false
+  showLoadingSpinner: false,
+  filters: {}
 };
 
 export function itemsReducer(items: Items = initialState, action: Action): Items {
@@ -28,27 +29,11 @@ export function itemsReducer(items: Items = initialState, action: Action): Items
       };
     case ItemsActions.FETCH_FAIL:
       return { ...items, showLoadingSpinner: false };
-    case ItemsActions.CREATE_SUCCESS:
-    case ItemsActions.UPDATE_SUCCESS:
-      return {
-        ...items,
-        results: {
-          ...items.results,
-          [action.payload.barcode]: action.payload
-        },
-        tempItemCustomFields: [],
-        tempItem: {}
-      };
-    case ItemsActions.DELETE_SUCCESS:
-      const results = Object.assign({}, items.results);
-      delete results[action.payload.id];
-      return {
-        ...items,
-        results,
-        tempItem: {}
-      };
     case ItemsActions.RESET:
-      return initialState;
+      return {
+        ...initialState,
+        filters: items.filters
+      };
     case ItemsActions.UPDATE_TEMP:
       return {
         ...items,
@@ -97,6 +82,14 @@ export function itemsReducer(items: Items = initialState, action: Action): Items
         ...items,
         tempItemCustomFields: action.payload.results,
         showLoadingSpinner: false
+      };
+    case ItemsActions.UPDATE_FILTERS:
+      return {
+        ...items,
+        filters: {
+          ...items.filters,
+          ...action.payload
+        }
       };
     default:
       return items;

--- a/src/store/kit-models/kit-models.effects.ts
+++ b/src/store/kit-models/kit-models.effects.ts
@@ -94,6 +94,7 @@ export class KitModelsEffects {
             results: store.kitModels.tempKitModels,
             kitID: action.payload.kitID
           }),
+          createAction(KitModelsActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, action.payload.message),
           createAction(AppActions.POP_NAV)

--- a/src/store/kit-models/kit-models.reducer.ts
+++ b/src/store/kit-models/kit-models.reducer.ts
@@ -26,14 +26,6 @@ export function kitModelsReducer(kitModels: KitModels = initialState, action: Ac
       };
     case KitModelsActions.FETCH_FAIL:
       return { ...kitModels, showLoadingSpinner: false };
-    case KitModelsActions.UPDATE_SUCCESS:
-      return {
-        ...kitModels,
-        results: {
-          [action.payload.kitID]: action.payload.results
-        },
-        tempKitModels: action.payload.results,
-      };
     case KitModelsActions.DELETE_TEMP:
       return {
         ...kitModels,

--- a/src/store/kits/kits.effects.spec.ts
+++ b/src/store/kits/kits.effects.spec.ts
@@ -75,6 +75,7 @@ describe('Kits Effects', () => {
     const expectedResult = [
       createAction(KitsActions.DELETE_SUCCESS, TestData.response),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+      createAction(KitsActions.FETCH),
       createAction(AppActions.SHOW_MESSAGE, Messages.kitDeleted),
       createAction(AppActions.POP_NAV)
     ];
@@ -110,6 +111,7 @@ describe('Kits Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(KitsActions.CREATE_SUCCESS, TestData.kit),
+      createAction(KitsActions.FETCH),
       createAction(KitModelsActions.UPDATE, {
         kitID: TestData.kit.kitID,
         message: Messages.kitAdded
@@ -148,6 +150,7 @@ describe('Kits Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(KitsActions.UPDATE_SUCCESS, TestData.kit),
+      createAction(KitsActions.FETCH),
       createAction(KitModelsActions.UPDATE, {
         kitID: TestData.kit.kitID,
         message: Messages.kitEdited

--- a/src/store/kits/kits.effects.ts
+++ b/src/store/kits/kits.effects.ts
@@ -42,6 +42,7 @@ export class KitsEffects {
       .concatMap(res => [
         createAction(KitsActions.DELETE_SUCCESS, res),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
+        createAction(KitsActions.FETCH),
         createAction(AppActions.SHOW_MESSAGE, Messages.kitDeleted),
         createAction(AppActions.POP_NAV)
       ])
@@ -61,6 +62,7 @@ export class KitsEffects {
     .mergeMap(action => this.kitData.createKit(action.payload)
       .concatMap(res => [
         createAction(KitsActions.CREATE_SUCCESS, res),
+        createAction(KitsActions.FETCH),
         createAction(KitModelsActions.UPDATE, {
           kitID: res.kitID,
           message: Messages.kitAdded
@@ -82,6 +84,7 @@ export class KitsEffects {
     .mergeMap(action => this.kitData.updateKit(action.payload)
       .concatMap(res => [
         createAction(KitsActions.UPDATE_SUCCESS, res),
+        createAction(KitsActions.FETCH),
         createAction(KitModelsActions.UPDATE, {
           kitID: res.kitID,
           message: Messages.kitEdited

--- a/src/store/kits/kits.reducer.ts
+++ b/src/store/kits/kits.reducer.ts
@@ -16,7 +16,6 @@ export function kitsReducer(kits: Kits = initialState, action: Action): Kits {
       return {
         ...kits,
         results: Object.assign({},
-          kits.results,
           action.payload.results.reduce((obj, kit) => {
             obj[kit.kitID] = kit;
             return obj;
@@ -26,19 +25,6 @@ export function kitsReducer(kits: Kits = initialState, action: Action): Kits {
       };
     case KitsActions.FETCH_FAIL:
       return { ...kits, showLoadingSpinner: false };
-    case KitsActions.DELETE_SUCCESS:
-      const results = Object.assign({}, kits.results);
-      delete results[action.payload.id];
-      return { ...kits, results };
-    case KitsActions.CREATE_SUCCESS:
-    case KitsActions.UPDATE_SUCCESS:
-      return {
-        ...kits,
-        results: {
-          ...kits.results,
-          [action.payload.kitID]: action.payload
-        }
-      };
     default:
       return kits;
   }

--- a/src/store/models/models.effects.spec.ts
+++ b/src/store/models/models.effects.spec.ts
@@ -76,6 +76,7 @@ describe('Models Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ModelsActions.CREATE_SUCCESS, TestData.response),
+      createAction(ModelsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.modelAdded),
     ];
@@ -96,6 +97,7 @@ describe('Models Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ModelsActions.CREATE_SUCCESS, TestData.response),
+      createAction(ModelsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.modelAdded),
       createAction(AppActions.POP_NAV)
@@ -135,6 +137,7 @@ describe('Models Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ModelsActions.UPDATE_SUCCESS, TestData.response),
+      createAction(ModelsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.modelEdited),
       createAction(AppActions.POP_NAV)
@@ -171,6 +174,7 @@ describe('Models Effects', () => {
     let performedActions = [];
     const expectedResult = [
       createAction(ModelsActions.DELETE_SUCCESS, TestData.response),
+      createAction(ModelsActions.FETCH),
       createAction(LayoutActions.HIDE_LOADING_MESSAGE),
       createAction(AppActions.SHOW_MESSAGE, Messages.modelDeleted),
       createAction(AppActions.POP_NAV)

--- a/src/store/models/models.effects.ts
+++ b/src/store/models/models.effects.ts
@@ -41,6 +41,7 @@ export class ModelsEffects {
       .concatMap(res => {
         let success = [
           createAction(ModelsActions.CREATE_SUCCESS, res),
+          createAction(ModelsActions.FETCH),
           createAction(LayoutActions.HIDE_LOADING_MESSAGE),
           createAction(AppActions.SHOW_MESSAGE, Messages.modelAdded),
         ];
@@ -67,6 +68,7 @@ export class ModelsEffects {
     .mergeMap(action => this.itemPropertyData.updateModel(action.payload, action.payload.modelID)
       .concatMap(res => [
         createAction(ModelsActions.UPDATE_SUCCESS, res),
+        createAction(ModelsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.modelEdited),
         createAction(AppActions.POP_NAV)
@@ -87,6 +89,7 @@ export class ModelsEffects {
     .mergeMap(action => this.itemPropertyData.deleteModel(action.payload)
       .concatMap(res => [
         createAction(ModelsActions.DELETE_SUCCESS, res),
+        createAction(ModelsActions.FETCH),
         createAction(LayoutActions.HIDE_LOADING_MESSAGE),
         createAction(AppActions.SHOW_MESSAGE, Messages.modelDeleted),
         createAction(AppActions.POP_NAV)

--- a/src/store/models/models.reducer.ts
+++ b/src/store/models/models.reducer.ts
@@ -29,22 +29,6 @@ export function modelsReducer(models: Models = initialState, action: Action): Mo
       };
     case ModelsActions.FETCH_FAIL:
       return { ...models, showLoadingSpinner: false };
-    case ModelsActions.CREATE_SUCCESS:
-    case ModelsActions.UPDATE_SUCCESS:
-      return {
-        ...models,
-        results: {
-          ...models.results,
-          [action.payload.modelID]: action.payload
-        }
-      };
-    case ModelsActions.DELETE_SUCCESS:
-      const results = Object.assign({}, models.results);
-      delete results[action.payload.id];
-      return {
-        ...models,
-        results
-      };
     case ModelsActions.FILTER:
       return Object.assign({}, models, {
         filtered: Object.keys(models.results)

--- a/src/test-data.ts
+++ b/src/test-data.ts
@@ -583,7 +583,14 @@ export class TestData {
           available: 0
         }
       ],
-      showLoadingSpinner: false
+      showLoadingSpinner: false,
+      filters: {
+        brandID: 1,
+        modelID: 2,
+        categoryID: 3,
+        available: true,
+        search: 'ca'
+      }
     },
     layout: {
       loadingMessage: 'Please wait...'
@@ -838,4 +845,12 @@ export class TestData {
       shouldUpdate: false
     }
   ];
+
+  public static itemFilters = {
+    brandID: 1,
+    modelID: 2,
+    categoryID: 3,
+    available: true,
+    search: 'ca'
+  };
 }


### PR DESCRIPTION
Closes #437 

This is done by dispatching a fetch action after any creation or update. This is done asynchronously with the actions to pop nav and hide loading messages, so users might experience a small delay in seeing the updated list while the page goes back.

However, I thought it would be very acceptable as the delay is only noticeable on very slow connections and making everything synchronous would have made the app feel slower and would have added a lot more complexity to the ngrx effects.

I also had to move the inventory filters to the ngrx store to refetch the items with the currently applied filters when going back after editing or creating an item.